### PR TITLE
Feat/env resolver backups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,11 +65,11 @@ jobs:
           BASE_REF: ${{ github.base_ref || 'main' }}
         run: |
           python -m pip install --quiet "diff-cover>=9"
-          git fetch --no-tags --depth=1 origin "$BASE_REF"
+          git fetch --no-tags origin "$BASE_REF"
           diff-cover coverage/lcov.info \
             --compare-branch="origin/$BASE_REF" \
             --fail-under=80 \
-            --markdown-report=diff-coverage.md
+            --format markdown:diff-coverage.md
           # Surface the report in the job summary.
           cat diff-coverage.md >> "$GITHUB_STEP_SUMMARY" || true
 

--- a/README.cli.md
+++ b/README.cli.md
@@ -60,8 +60,50 @@ vault env rollback 3 -e dev      # restore a previous version of "dev"
 vault env run dev -- npm start   # run a command with the env injected
 ```
 
-Other commands: `rm`, `delete`, `rename`, `squash`, `change-password`. Run
-`vault env <command> --help` for the full options of any command.
+#### Layering & template references
+
+Environments can **extend** a parent so shared variables live in one place, and
+values can **reference** another variable with `{{env:<name>/<KEY>}}` (use
+`_self` for the same environment). Both are resolved on read — by `export`,
+`run`, `get`, `diff`, and `validate` — so the stored value keeps its reference
+and re-resolves whenever the source changes.
+
+```bash
+# Shared defaults in a "base" environment
+vault env set LOG_LEVEL info -e base --public
+vault env set PORT 3000 -e base --public --required
+
+# "staging" inherits base, then overrides. Any `set` creates the environment;
+# `extends` wires the parent (which must already exist; --none clears it).
+vault env set API_URL https://staging.example.com -e staging --public
+vault env extends staging base
+vault env set PORT 8080 -e staging --public           # override an inherited value
+
+# Reference another environment, or your own keys with _self.
+# --extends sets the parent in the same step as the write.
+vault env set --extends base DB_URL '{{env:staging/API_URL}}' -e dev
+vault env set ENDPOINT 'localhost:{{env:_self/PORT}}' -e dev   # PORT inherited from base
+
+vault env export staging --format json   # base keys merged in (PORT shows 8080)
+vault env validate dev                   # required keys aggregated across the chain; all refs must resolve
+```
+
+Layering and references support chains up to 5 deep; circular `extends`,
+circular references, and missing keys are reported as validation errors.
+
+Wire layering up front at import time (import every environment in the chain):
+
+```bash
+vault env init --env base:.env.base --env staging:.env.staging --extends staging:base
+```
+
+Other commands: `rm`, `delete`, `rename`, `copy`, `squash`, `extends`,
+`change-password`. Run `vault env <command> --help` for the full options of any
+command.
+
+> **Safety:** every write keeps a `<vault>.bak` of the previous good state and
+> writes atomically, so an interrupted save can never corrupt the vault.
+> Deleting an environment also leaves a timestamped `<vault>.deleted.<ts>` copy.
 
 ## Where data is stored
 

--- a/README.cli.md
+++ b/README.cli.md
@@ -64,7 +64,7 @@ vault env run dev -- npm start   # run a command with the env injected
 
 Environments can **extend** a parent so shared variables live in one place, and
 values can **reference** another variable with `{{env:<name>/<KEY>}}` (use
-`_self` for the same environment). Both are resolved on read — by `export`,
+`self` for the same environment). Both are resolved on read — by `export`,
 `run`, `get`, `diff`, and `validate` — so the stored value keeps its reference
 and re-resolves whenever the source changes.
 
@@ -79,10 +79,10 @@ vault env set API_URL https://staging.example.com -e staging --public
 vault env extends staging base
 vault env set PORT 8080 -e staging --public           # override an inherited value
 
-# Reference another environment, or your own keys with _self.
+# Reference another environment, or your own keys with self.
 # --extends sets the parent in the same step as the write.
 vault env set --extends base DB_URL '{{env:staging/API_URL}}' -e dev
-vault env set ENDPOINT 'localhost:{{env:_self/PORT}}' -e dev   # PORT inherited from base
+vault env set ENDPOINT 'localhost:{{env:self/PORT}}' -e dev   # PORT inherited from base
 
 vault env export staging --format json   # base keys merged in (PORT shows 8080)
 vault env validate dev                   # required keys aggregated across the chain; all refs must resolve

--- a/bin/commands/env.js
+++ b/bin/commands/env.js
@@ -54,6 +54,23 @@ async function copyToClipboard(text, label) {
   }
 }
 
+function parseExtendsOption(val) {
+  const entries = {};
+  for (const pair of val.split(',')) {
+    const sep = pair.includes('=') ? '=' : ':';
+    const idx = pair.indexOf(sep);
+    const child = idx === -1 ? '' : pair.slice(0, idx).trim();
+    const parent = idx === -1 ? '' : pair.slice(idx + 1).trim();
+    if (!child || !parent) {
+      throw new Error(
+        `Invalid --extends format: "${pair}". Expected envName:parentName`
+      );
+    }
+    entries[child] = parent;
+  }
+  return entries;
+}
+
 function parseEnvOption(val) {
   const entries = {};
   for (const pair of val.split(',')) {
@@ -177,6 +194,12 @@ export function registerEnvCommand(program) {
       (val, prev = {}) => ({ ...prev, ...parseEnvOption(val) }),
       {}
     )
+    .option(
+      '--extends <pairs>',
+      'Set layering: envName:parentName (repeatable, comma-separated)',
+      (val, prev = {}) => ({ ...prev, ...parseExtendsOption(val) }),
+      {}
+    )
     .action(async (options) => {
       try {
         const vaultPassword = await resolvePassword(
@@ -221,6 +244,16 @@ export function registerEnvCommand(program) {
             message: 'Initial import',
           });
           step.succeed(`Imported ${chalk.bold(envName)} (${count} variables)`);
+        }
+
+        // Apply --extends layering once all environments exist in the model.
+        for (const [child, parent] of Object.entries(options.extends || {})) {
+          try {
+            vaultModel.setExtends(child, parent);
+          } catch (err) {
+            console.error(chalk.red(err.message));
+            process.exit(1);
+          }
         }
 
         const step = ora('Encrypting vault…').start();
@@ -310,6 +343,7 @@ export function registerEnvCommand(program) {
     .option('-e, --env <name>', 'Environment name (defaults to "default")')
     .option('--public', 'Mark variable as non-sensitive')
     .option('--required', 'Mark variable as required (checked by validate)')
+    .option('--extends <parent>', 'Set this environment to extend <parent>')
     .option('-m, --message <text>', 'Version message')
     .action(async (key, value, options) => {
       try {
@@ -359,6 +393,21 @@ export function registerEnvCommand(program) {
         if (!result.success) {
           spinner.fail(chalk.red(result.error));
           process.exit(1);
+        }
+
+        // Apply --extends after the write so the environment is guaranteed to
+        // exist (setEnv auto-creates it on first use).
+        if (options.extends) {
+          const extendsResult = await EnvironmentVaultService.setExtends(
+            vaultPath,
+            vaultPassword,
+            envName,
+            options.extends
+          );
+          if (!extendsResult.success) {
+            spinner.fail(chalk.red(extendsResult.error));
+            process.exit(1);
+          }
         }
 
         spinner.succeed(chalk.green(`Set ${key} in "${envName}".`));
@@ -580,16 +629,17 @@ export function registerEnvCommand(program) {
           process.exit(1);
         }
 
+        // JSON format returns an object; emit valid JSON (not util.inspect)
+        // so the output can be piped, e.g. into `docker compose --env-file`.
+        const text =
+          typeof result.data === 'string'
+            ? result.data
+            : JSON.stringify(result.data, null, 2);
+
         if (options.clip) {
-          const text =
-            typeof result.data === 'string'
-              ? result.data
-              : JSON.stringify(result.data, null, 2);
           await copyToClipboard(text, 'export');
-          console.log(text);
-        } else {
-          console.log(result.data);
         }
+        console.log(text);
       } catch (error) {
         console.error(chalk.red(error.message));
         process.exit(1);
@@ -658,6 +708,64 @@ export function registerEnvCommand(program) {
         }
 
         spinner.succeed(chalk.green(`Renamed "${oldName}" to "${newName}".`));
+      } catch (error) {
+        spinner.fail(chalk.red(error.message));
+        process.exit(1);
+      }
+    });
+
+  env
+    .command('extends')
+    .description('Set or clear the parent an environment extends (layering)')
+    .argument('<envName>', 'Environment to configure')
+    .argument('[parent]', 'Parent environment to extend (omit with --none)')
+    .option('-n, --name <name>', 'Vault name')
+    .option('-v, --vault <path>', 'Exact vault file path')
+    .option('--password <password>', 'Vault password (non-interactive)')
+    .option('--password-file <path>', 'Read vault password from a file')
+    .option('--password-stdin', 'Read vault password from stdin')
+    .option('--none', 'Clear the parent (stop extending)')
+    .action(async (envName, parent, options) => {
+      if (!options.none && !parent) {
+        console.error(
+          chalk.red('Specify a <parent> environment, or pass --none to clear.')
+        );
+        process.exit(1);
+      }
+      if (options.none && parent) {
+        console.error(chalk.red('Pass either a <parent> or --none, not both.'));
+        process.exit(1);
+      }
+
+      const target = options.none ? null : parent;
+      const spinner = ora(
+        target
+          ? `Setting "${envName}" to extend "${target}"...`
+          : `Clearing parent of "${envName}"...`
+      ).start();
+
+      try {
+        const { vaultPath, vaultPassword } = await loadVault(options);
+
+        const result = await EnvironmentVaultService.setExtends(
+          vaultPath,
+          vaultPassword,
+          envName,
+          target
+        );
+
+        if (!result.success) {
+          spinner.fail(chalk.red(result.error));
+          process.exit(1);
+        }
+
+        spinner.succeed(
+          chalk.green(
+            target
+              ? `"${envName}" now extends "${target}".`
+              : `"${envName}" no longer extends a parent.`
+          )
+        );
       } catch (error) {
         spinner.fail(chalk.red(error.message));
         process.exit(1);

--- a/docs/environments/SPEC.md
+++ b/docs/environments/SPEC.md
@@ -3,7 +3,7 @@
 > Feature: Securely manage, version, and inject environment variables from an encrypted
 > `.env.vault` file into development tools, build processes, and CI/CD pipelines.
 >
-> Status: **Draft** · Revision 1
+> Status: **v1.5 delivered** · Revision 6
 
 ---
 
@@ -1364,10 +1364,15 @@ Foundation  Developer     Composition    Agent & Mount   Integration     North S
                      MVP            Power User                       Vision
 ```
 
+> **Legend:** ✅ delivered · ◑ partial (see note) · ☐ not started. Status
+> reflects the current implementation as of Revision 6.
+
 ### 13.2 v0.5 — Foundation
 
 > **Goal**: Prove the encrypted env vault works. Basic CRUD, import from existing
 > `.env` files, clipboard copy.
+
+**Status:** ✅ Delivered.
 
 | Deliverable                            | Description                                                             |
 | -------------------------------------- | ----------------------------------------------------------------------- |
@@ -1396,22 +1401,22 @@ the vault, and `vault env get staging API_URL --clip` copies the value to clipbo
 > **Goal**: The primary workflow — `vault env run` — works. Versioning is reliable.
 > This is the first version suitable for daily use.
 
-| Deliverable                          | Description                                                   |
-| ------------------------------------ | ------------------------------------------------------------- | ----- | ---------------------------------------- |
-| `vault env run` with `--inject clean | merge                                                         | file` | Full CLI runner with all injection modes |
-| `--env-file` flag                    | Temp file creation and secure cleanup                         |
-| Environment versioning               | Multiple versions per env; `history`, `rollback`              |
-| `vault env squash`                   | Compress version history with `--keep`                        |
-| `vault env template`                 | `.env.example` export                                         |
-| `vault env validate`                 | Required keys check                                           |
-| `vault env diff`                     | Diff between two environments                                 |
-| `vault env change-password`          | Re-encrypt with new password                                  |
-| `vault env copy`                     | Duplicate an environment                                      |
-| `vault env rename`                   | Rename an environment                                         |
-| Temp file cleanup                    | Secure deletion (overwrite + unlink), orphan cleanup          |
-| Discovery                            | App-data-first, `--name` / `--vault` resolution               |
-| `--json` flag                        | Machine-readable output for `show`, `list`, `history`, `diff` |
-| Error messages                       | Clear messages for wrong password, missing env, missing key   |
+**Status:** ✅ Delivered, with two hardening follow-ups (◑ below).
+
+| Deliverable                               | Description                                                                                                                     |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| ✅ `vault env run` (`clean\|merge\|file`) | Full CLI runner with all injection modes (`--env-file` exposed as `--out-file`)                                                 |
+| ✅ Environment versioning                 | Multiple versions per env; `history`, `rollback`                                                                                |
+| ✅ `vault env squash`                     | Compress version history with `--keep`                                                                                          |
+| ✅ `vault env template`                   | `.env.example` export                                                                                                           |
+| ✅ `vault env validate`                   | Required keys check (expanded in v1.5)                                                                                          |
+| ✅ `vault env diff`                       | Diff between two environments                                                                                                   |
+| ✅ `vault env change-password`            | Re-encrypt with new password                                                                                                    |
+| ✅ `vault env copy` / `rename`            | Duplicate / rename an environment                                                                                               |
+| ◑ Temp file cleanup                       | Secure deletion done, but single-pass overwrite and **no orphan-scan** (SPEC §12.3 wants 3 passes + cleanup)                    |
+| ✅ Discovery                              | App-data-first, walk-up, `--name` / `--vault` resolution                                                                        |
+| ✅ `--json` flag                          | Machine-readable output for `show`, `list`, `history`, `diff`                                                                   |
+| ◑ Error messages                          | Missing env/key clear; **wrong-password vs corrupted not distinguished** and symbolic/numeric codes unwired (§16.5, Appendix B) |
 
 **Dependencies**: v0.5
 
@@ -1423,25 +1428,36 @@ the vault, and `vault env get staging API_URL --clip` copies the value to clipbo
 
 > **Goal**: Power-user features for complex projects with multiple environments.
 
-| Deliverable                      | Description                                                  |
-| -------------------------------- | ------------------------------------------------------------ |
-| `extends` / environment layering | `staging extends base` merge                                 |
-| Template refs `{{env:name/KEY}}` | Cross-environment references within the vault                |
-| Full validation engine           | Template resolution, cycle detection, extends validation     |
-| `vault env validate --strict`    | Warnings promoted to errors                                  |
-| App-data fallback path           | Auto-discovery to `~/.secure-vault/envs/<dirname>.env.vault` |
-| Environment `description` field  | Human-readable labels                                        |
-| `--message` on `set`             | Version messages for history clarity                         |
+**Status:** ✅ Delivered (`EnvironmentResolver` + backup safety net).
+
+| Deliverable                         | Description                                                                                                |
+| ----------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| ✅ `extends` / environment layering | `staging extends base` merge; set via `vault env extends`, `--extends` on `set`/`init`. `self` is reserved |
+| ✅ Template refs `{{env:name/KEY}}` | Cross-environment + `{{env:self/KEY}}` references, resolved on read by `run`/`export`/`get`/`diff`         |
+| ✅ Full validation engine           | Template resolution, cycle detection (template + extends), depth cap, aggregated `required`, secret-scan   |
+| ✅ `vault env validate --strict`    | Warnings promoted to errors (exit 0/1/2 per §10.2)                                                         |
+| ✅ App-data fallback path           | Auto-discovery to `<app-data>/envs/<dirname>.env.vault`                                                    |
+| ✅ Environment `description` field  | Human-readable labels                                                                                      |
+| ✅ `--message` on `set`             | Version messages for history clarity                                                                       |
 
 **Dependencies**: v1.0
 
-**Exit criteria**: A team can define `base → staging → production` with template refs and layering, validate all three, and run any of them.
+**Also delivered here (beyond the original scope):** write-time `<vault>.bak` +
+atomic rename so an interrupted save cannot corrupt the vault, a
+`<vault>.deleted.<ts>` snapshot on environment deletion (§5.4), and a fix for
+`export --format json` emitting `util.inspect` output instead of valid JSON.
+Deferred: rotating "keep last 5" backups (§15 Q4) and a `vault env restore`
+command (recovery is currently a manual `cp <vault>.bak <vault>`).
+
+**Exit criteria**: A team can define `base → staging → production` with template refs and layering, validate all three, and run any of them. ✅ Verified end-to-end.
 
 ---
 
 ### 13.5 v2.0 — Agent & Mount
 
 > **Goal**: Long-running dev server support with persistent file mounts.
+
+**Status:** ☐ Not started.
 
 | Deliverable                           | Description                                               |
 | ------------------------------------- | --------------------------------------------------------- |
@@ -1464,6 +1480,8 @@ the vault, and `vault env get staging API_URL --clip` copies the value to clipbo
 
 > **Goal**: Connect the env vault to the main vault and to external systems.
 
+**Status:** ☐ Not started.
+
 | Deliverable                      | Description                                                              |
 | -------------------------------- | ------------------------------------------------------------------------ |
 | `{{vault:...}}` cross-vault refs | Reference entries in the main password vault                             |
@@ -1482,6 +1500,8 @@ the vault, and `vault env get staging API_URL --clip` copies the value to clipbo
 ### 13.7 v3.0 — North Star (Vision)
 
 > **Goal**: Zero-overhead, zero-trust secrets management for the entire development lifecycle.
+
+**Status:** ☐ Not started.
 
 | Deliverable                    | Description                                                                 |
 | ------------------------------ | --------------------------------------------------------------------------- |
@@ -1604,6 +1624,13 @@ Questions that need resolution before implementation:
 | 4   | Backup strategy for `.env.vault`?                     | Timestamped backups on write, keep last N    | Keep last 5 backups            |
 | 5   | Should `vault env export` include comments?           | (a) No (b) Yes, from description fields      | (b) — useful for documentation |
 | 6   | Allowlist defaults: which system vars?                | `PATH`, `HOME`, `SHELL`, `USER`, `TMPDIR`    | As listed                      |
+
+> **Resolved by implementation (Rev 6):** Q2 → (a) — `required` is aggregated
+> across the extends chain (§9.5). Q4 → partial — writes keep a single
+> previous-good `.bak` with atomic rename, plus a `.deleted.<ts>` snapshot on
+> environment deletion; rotating "keep last N" is deferred. Q3/Q6 match the
+> implemented limits/allowlist. **Still open:** Q1 (multi-env `run`) and Q5
+> (`export` comments from `description`).
 
 ---
 
@@ -1863,10 +1890,11 @@ or — worse — makes the test pass against fs-extra while production drifts.
 
 ## Appendix C: Changelog
 
-| Date       | Revision | Author  | Changes                                                                                                                                                           |
-| ---------- | -------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 2026-05-30 | 1        | wbenzid | Initial draft                                                                                                                                                     |
-| 2026-05-26 | 2        | wbenzid | Add §16 Known Issues & Pending Reconciliations (8 items from v0.1.0-rc.5 e2e validation)                                                                          |
-| 2026-06-06 | 3        | wbenzid | Codify var-level vs env-level command split (§6.1, §6.1.1); align all §6.3 usage/examples and §7 flows to the implementation; mark §16.1–16.3 RESOLVED (option b) |
-| 2026-06-06 | 4        | wbenzid | Document password resolution (§6.2.1: precedence, mutual exclusion, exit codes); update §12.5; add `PASSWORD_*` codes to Appendix B; mark §16.5 RESOLVED (docs)   |
-| 2026-06-06 | 5        | wbenzid | Document walk-up + git-root vault discovery (§5.2/§5.3); mark §16.6 RESOLVED. Fix duplicate §6.1 heading (now §6.1.1/6.1.2/6.1.3) and stale cross-refs            |
+| Date       | Revision | Author  | Changes                                                                                                                                                                                                                                                                                                   |
+| ---------- | -------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-05-30 | 1        | wbenzid | Initial draft                                                                                                                                                                                                                                                                                             |
+| 2026-05-26 | 2        | wbenzid | Add §16 Known Issues & Pending Reconciliations (8 items from v0.1.0-rc.5 e2e validation)                                                                                                                                                                                                                  |
+| 2026-06-06 | 3        | wbenzid | Codify var-level vs env-level command split (§6.1, §6.1.1); align all §6.3 usage/examples and §7 flows to the implementation; mark §16.1–16.3 RESOLVED (option b)                                                                                                                                         |
+| 2026-06-06 | 4        | wbenzid | Document password resolution (§6.2.1: precedence, mutual exclusion, exit codes); update §12.5; add `PASSWORD_*` codes to Appendix B; mark §16.5 RESOLVED (docs)                                                                                                                                           |
+| 2026-06-06 | 5        | wbenzid | Document walk-up + git-root vault discovery (§5.2/§5.3); mark §16.6 RESOLVED. Fix duplicate §6.1 heading (now §6.1.1/6.1.2/6.1.3) and stale cross-refs                                                                                                                                                    |
+| 2026-06-11 | 6        | wbenzid | Mark v1.5 Composition delivered (resolver: `extends` layering + `{{env:name/KEY}}`/`{{env:self/KEY}}` refs + full validation engine); add `.bak`/atomic-write + `.deleted.<ts>` (§5.4); reserve `self` env name (§4.5/§8); add milestone status legend + v0.5/v1.0/v2.x markers; note Q1/Q4 status in §15 |

--- a/docs/environments/SPEC.md
+++ b/docs/environments/SPEC.md
@@ -314,6 +314,7 @@ v2 (or vice versa).
 ### 4.5 Naming Constraints
 
 - Environment names: `[a-z0-9][a-z0-9_-]*` (lowercase, no leading/trailing hyphens)
+- Reserved environment names (case-insensitive): `self` — collides with the `{{env:self/KEY}}` self-reference keyword (§8.2)
 - Key names: `[A-Z_][A-Z0-9_]*` (uppercase convention, enforced by validation)
 - Max environments per vault: 100
 - Max versions per environment: 1000 (squash to compress)
@@ -1095,7 +1096,7 @@ segment = [a-zA-Z0-9._-]+
 | Pattern                          | Resolution Target                         | Scope |
 | -------------------------------- | ----------------------------------------- | ----- |
 | `{{env:name/VAR_NAME}}`          | Another environment's resolved `VAR_NAME` | v1    |
-| `{{env:_self/VAR_NAME}}`         | Same environment's resolved `VAR_NAME`    | v1    |
+| `{{env:self/VAR_NAME}}`          | Same environment's resolved `VAR_NAME`    | v1    |
 | `{{vault:entries/<id>/<field>}}` | Main vault entry's field                  | v2+   |
 | `{{vault:meta/username}}`        | Vault metadata                            | v2+   |
 
@@ -1106,7 +1107,7 @@ segment = [a-zA-Z0-9._-]+
 3. **Recursion**: Values are scanned for `{{...}}` patterns. If a resolved value itself contains a ref, resolve again (max depth = 5).
 4. **Cycle detection**: A cycle (A → B → A) is detected and reported as an error.
 5. **Forward refs**: Allowed. Environment B can reference environment A even if A is defined after B in the file.
-6. **Self-refs**: `{{env:_self/KEY}}` allows aliasing within the same env. Forms a trivial cycle if KEY references itself — this is detected and blocked.
+6. **Self-refs**: `{{env:self/KEY}}` allows aliasing within the same env. Forms a trivial cycle if KEY references itself — this is detected and blocked. `self` is a reserved environment name (see §4.5) so it can never be shadowed by a real environment.
 7. **Missing source**: If `{{env:MISSING/KEY}}` references a non-existent environment, fail with `"Environment 'MISSING' not found"`.
 8. **Missing key**: If `{{env:staging/MISSING}}` references a key not in staging, fail with `"Key 'MISSING' not found in environment 'staging'"`.
 

--- a/src/__tests__/cli/envResolver.integration.test.js
+++ b/src/__tests__/cli/envResolver.integration.test.js
@@ -1,0 +1,122 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CLI = path.resolve(__dirname, '../../../bin/cli.js');
+const NODE = process.execPath;
+const PASSWORD = 'TestVault123!@#';
+
+let vaultPath;
+
+function cli(args, extraEnv = {}) {
+  // Insert `-v <vaultPath>` before any `--` so `run` never swallows it into
+  // the child command.
+  const sep = args.indexOf('--');
+  const withVault =
+    sep === -1
+      ? [...args, '-v', vaultPath]
+      : [...args.slice(0, sep), '-v', vaultPath, ...args.slice(sep)];
+  return spawnSync(NODE, [CLI, 'env', ...withVault], {
+    encoding: 'utf8',
+    env: { ...process.env, VAULT_ENV_PASSWORD: PASSWORD, ...extraEnv },
+  });
+}
+
+beforeAll(() => {
+  vaultPath = path.join(
+    fs.mkdtempSync(path.join(os.tmpdir(), 'sv-resolver-')),
+    'test.env.vault'
+  );
+
+  // base → staging → dev, with a template ref from dev into staging.
+  cli(['init']);
+  cli(['set', 'PORT', '3000', '-e', 'base', '--public', '--required']);
+  cli([
+    'set',
+    'API_URL',
+    'https://staging.example.com',
+    '-e',
+    'staging',
+    '--public',
+  ]);
+  cli(['extends', 'staging', 'base']);
+  cli([
+    'set',
+    'DB_URL',
+    '{{env:staging/API_URL}}',
+    '-e',
+    'dev',
+    '--extends',
+    'staging',
+  ]);
+});
+
+afterAll(() => {
+  try {
+    fs.rmSync(path.dirname(vaultPath), { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+describe('vault env resolution (layering + templates)', () => {
+  it('export resolves inherited and templated vars', () => {
+    const r = cli(['export', 'dev', '--format', 'json']);
+    expect(r.status).toBe(0);
+    const vars = JSON.parse(r.stdout);
+    expect(vars.PORT).toBe('3000'); // inherited from base
+    expect(vars.API_URL).toBe('https://staging.example.com'); // from staging
+    expect(vars.DB_URL).toBe('https://staging.example.com'); // template resolved
+  });
+
+  it('run injects the resolved environment', () => {
+    const r = cli([
+      'run',
+      'dev',
+      '--',
+      NODE,
+      '-e',
+      'process.stdout.write(JSON.stringify({DB:process.env.DB_URL,PORT:process.env.PORT}))',
+    ]);
+    expect(r.status).toBe(0);
+    expect(JSON.parse(r.stdout)).toEqual({
+      DB: 'https://staging.example.com',
+      PORT: '3000',
+    });
+  });
+
+  it('validate passes with the aggregated required key satisfied', () => {
+    const r = cli(['validate', 'dev']);
+    expect(r.status).toBe(0); // PORT (required in base) is present after layering
+    expect(r.stdout).toContain('required');
+  });
+
+  it('validate flags an unresolved reference as an error', () => {
+    const broken = path.join(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'sv-broken-')),
+      'b.env.vault'
+    );
+    const run = (args) =>
+      spawnSync(NODE, [CLI, 'env', ...args, '-v', broken], {
+        encoding: 'utf8',
+        env: { ...process.env, VAULT_ENV_PASSWORD: PASSWORD },
+      });
+    run(['init']);
+    run(['set', 'X', '{{env:ghost/Y}}', '-e', 'dev']);
+
+    const r = run(['validate', 'dev']);
+    expect(r.status).toBe(1); // errors → exit 1
+    expect(r.stdout).toMatch(/not found/i);
+
+    fs.rmSync(path.dirname(broken), { recursive: true, force: true });
+  });
+
+  it('writes a .bak after a mutating write', () => {
+    expect(fs.existsSync(`${vaultPath}.bak`)).toBe(true);
+  });
+});

--- a/src/__tests__/electron/services/EnvironmentResolver.test.js
+++ b/src/__tests__/electron/services/EnvironmentResolver.test.js
@@ -1,0 +1,197 @@
+// @vitest-environment node
+import { EnvironmentResolver } from '../../../electron/services/EnvironmentResolver.js';
+import { EnvironmentVault } from '../../../electron/models/EnvironmentVault.js';
+
+/** Build a vault from a setup callback that receives the model instance. */
+function buildVault(setup) {
+  const vault = new EnvironmentVault();
+  setup(vault);
+  return vault;
+}
+
+/** base → staging → dev layering chain used by several tests. */
+function layeredVault() {
+  return buildVault((v) => {
+    v.addEnvironment('base');
+    v.addVersion(
+      'base',
+      { LOG_LEVEL: 'info', PORT: '3000' },
+      { required: ['PORT'] }
+    );
+
+    v.addEnvironment('staging');
+    v.addVersion(
+      'staging',
+      { API_URL: 'https://staging.example.com', NODE_ENV: 'staging' },
+      { required: ['API_URL'] }
+    );
+    v.setExtends('staging', 'base');
+
+    v.addEnvironment('dev');
+    v.addVersion('dev', { API_URL: 'http://localhost:3000' });
+    v.setExtends('dev', 'staging');
+  });
+}
+
+describe('EnvironmentResolver', () => {
+  describe('resolveEnvironment — layering', () => {
+    it('returns own vars for an environment with no extends', () => {
+      const vault = buildVault((v) => {
+        v.addEnvironment('base');
+        v.addVersion('base', { LOG_LEVEL: 'info', PORT: '3000' });
+      });
+      const resolver = new EnvironmentResolver(vault);
+      expect(resolver.resolveEnvironment('base')).toEqual({
+        LOG_LEVEL: 'info',
+        PORT: '3000',
+      });
+    });
+
+    it('merges the extends chain with the child overriding ancestors', () => {
+      const resolver = new EnvironmentResolver(layeredVault());
+      const dev = resolver.resolveEnvironment('dev');
+      expect(dev.LOG_LEVEL).toBe('info'); // from base
+      expect(dev.PORT).toBe('3000'); // from base
+      expect(dev.NODE_ENV).toBe('staging'); // from staging
+      expect(dev.API_URL).toBe('http://localhost:3000'); // dev overrides staging
+    });
+  });
+
+  describe('resolveEnvironment — template references', () => {
+    it('resolves a cross-environment {{env:name/KEY}} ref', () => {
+      const vault = layeredVault();
+      vault.addVersion('dev', {
+        API_URL: 'http://localhost:3000',
+        DB_URL: '{{env:staging/API_URL}}',
+      });
+      const resolver = new EnvironmentResolver(vault);
+      expect(resolver.resolveEnvironment('dev').DB_URL).toBe(
+        'https://staging.example.com'
+      );
+    });
+
+    it('resolves a {{env:_self/KEY}} ref against the layered map', () => {
+      const vault = buildVault((v) => {
+        v.addEnvironment('dev');
+        v.addVersion('dev', {
+          API_URL: 'http://localhost',
+          ALIAS: '{{env:_self/API_URL}}',
+        });
+      });
+      const resolver = new EnvironmentResolver(vault);
+      expect(resolver.resolveEnvironment('dev').ALIAS).toBe('http://localhost');
+    });
+
+    it('resolves a ref that points at an inherited key', () => {
+      const vault = layeredVault();
+      // dev references PORT, which it inherits from base via staging.
+      vault.addVersion('dev', { ECHO: '{{env:_self/PORT}}' });
+      const resolver = new EnvironmentResolver(vault);
+      expect(resolver.resolveEnvironment('dev').ECHO).toBe('3000');
+    });
+
+    it('throws on a reference to a missing environment', () => {
+      const vault = buildVault((v) => {
+        v.addEnvironment('dev');
+        v.addVersion('dev', { X: '{{env:ghost/Y}}' });
+      });
+      const resolver = new EnvironmentResolver(vault);
+      expect(() => resolver.resolveEnvironment('dev')).toThrow(/not found/i);
+    });
+
+    it('throws on a reference to a missing key', () => {
+      const vault = buildVault((v) => {
+        v.addEnvironment('a');
+        v.addVersion('a', { K: 'v' });
+        v.addEnvironment('dev');
+        v.addVersion('dev', { X: '{{env:a/MISSING}}' });
+      });
+      const resolver = new EnvironmentResolver(vault);
+      expect(() => resolver.resolveEnvironment('dev')).toThrow(/not found/i);
+    });
+
+    it('detects a template reference cycle', () => {
+      const vault = buildVault((v) => {
+        v.addEnvironment('a');
+        v.addVersion('a', { X: '{{env:b/X}}' });
+        v.addEnvironment('b');
+        v.addVersion('b', { X: '{{env:a/X}}' });
+      });
+      const resolver = new EnvironmentResolver(vault);
+      expect(() => resolver.resolveEnvironment('a')).toThrow(/circular/i);
+    });
+
+    it('detects a trivial self-reference cycle', () => {
+      const vault = buildVault((v) => {
+        v.addEnvironment('a');
+        v.addVersion('a', { X: '{{env:_self/X}}' });
+      });
+      const resolver = new EnvironmentResolver(vault);
+      expect(() => resolver.resolveEnvironment('a')).toThrow(/circular/i);
+    });
+  });
+
+  describe('resolveEnvironment — extends chain integrity', () => {
+    it('detects a circular extends chain', () => {
+      const vault = buildVault((v) => {
+        v.addEnvironment('a');
+        v.addVersion('a', { X: '1' });
+        v.addEnvironment('b');
+        v.addVersion('b', { Y: '2' });
+        v.setExtends('a', 'b');
+        v.setExtends('b', 'a');
+      });
+      const resolver = new EnvironmentResolver(vault);
+      expect(() => resolver.resolveEnvironment('a')).toThrow(
+        /circular extends/i
+      );
+    });
+
+    it('rejects an extends chain deeper than the max', () => {
+      const vault = buildVault((v) => {
+        for (let i = 0; i <= 6; i++) v.addEnvironment(`e${i}`);
+        for (let i = 0; i < 6; i++) v.setExtends(`e${i}`, `e${i + 1}`);
+      });
+      const resolver = new EnvironmentResolver(vault);
+      expect(() => resolver.resolveEnvironment('e0')).toThrow(/max depth/i);
+    });
+  });
+
+  describe('aggregateRequired', () => {
+    it('unions required keys across the extends chain, deduped', () => {
+      const vault = buildVault((v) => {
+        v.addEnvironment('base');
+        v.addVersion('base', { PORT: '3000' }, { required: ['PORT'] });
+        v.addEnvironment('staging');
+        v.addVersion(
+          'staging',
+          { API_URL: 'x', PORT: '8080' },
+          { required: ['API_URL', 'PORT'] }
+        );
+        v.setExtends('staging', 'base');
+      });
+      const resolver = new EnvironmentResolver(vault);
+      expect(resolver.aggregateRequired('staging').sort()).toEqual([
+        'API_URL',
+        'PORT',
+      ]);
+    });
+  });
+
+  describe('resolveValue', () => {
+    it('resolves a single inherited and templated key', () => {
+      const vault = layeredVault();
+      vault.addVersion('dev', { DB_URL: '{{env:staging/API_URL}}' });
+      const resolver = new EnvironmentResolver(vault);
+      expect(resolver.resolveValue('dev', 'DB_URL')).toBe(
+        'https://staging.example.com'
+      );
+      expect(resolver.resolveValue('dev', 'PORT')).toBe('3000'); // inherited
+    });
+
+    it('throws when the key is absent after inheritance', () => {
+      const resolver = new EnvironmentResolver(layeredVault());
+      expect(() => resolver.resolveValue('dev', 'NOPE')).toThrow(/not found/i);
+    });
+  });
+});

--- a/src/__tests__/electron/services/EnvironmentResolver.test.js
+++ b/src/__tests__/electron/services/EnvironmentResolver.test.js
@@ -70,12 +70,12 @@ describe('EnvironmentResolver', () => {
       );
     });
 
-    it('resolves a {{env:_self/KEY}} ref against the layered map', () => {
+    it('resolves a {{env:self/KEY}} ref against the layered map', () => {
       const vault = buildVault((v) => {
         v.addEnvironment('dev');
         v.addVersion('dev', {
           API_URL: 'http://localhost',
-          ALIAS: '{{env:_self/API_URL}}',
+          ALIAS: '{{env:self/API_URL}}',
         });
       });
       const resolver = new EnvironmentResolver(vault);
@@ -85,7 +85,7 @@ describe('EnvironmentResolver', () => {
     it('resolves a ref that points at an inherited key', () => {
       const vault = layeredVault();
       // dev references PORT, which it inherits from base via staging.
-      vault.addVersion('dev', { ECHO: '{{env:_self/PORT}}' });
+      vault.addVersion('dev', { ECHO: '{{env:self/PORT}}' });
       const resolver = new EnvironmentResolver(vault);
       expect(resolver.resolveEnvironment('dev').ECHO).toBe('3000');
     });
@@ -124,7 +124,7 @@ describe('EnvironmentResolver', () => {
     it('detects a trivial self-reference cycle', () => {
       const vault = buildVault((v) => {
         v.addEnvironment('a');
-        v.addVersion('a', { X: '{{env:_self/X}}' });
+        v.addVersion('a', { X: '{{env:self/X}}' });
       });
       const resolver = new EnvironmentResolver(vault);
       expect(() => resolver.resolveEnvironment('a')).toThrow(/circular/i);

--- a/src/__tests__/electron/services/EnvironmentVaultService.test.js
+++ b/src/__tests__/electron/services/EnvironmentVaultService.test.js
@@ -466,6 +466,46 @@ describe('EnvironmentVaultService', () => {
     });
   });
 
+  describe('reserved environment names', () => {
+    it('rejects creating an environment named "self"', () => {
+      const vault = new EnvironmentVault();
+      expect(() => vault.addEnvironment('self')).toThrow(/reserved/i);
+    });
+
+    it('rejects "self" case-insensitively', () => {
+      const vault = new EnvironmentVault();
+      expect(() => vault.addEnvironment('SELF')).toThrow(/reserved/i);
+    });
+
+    it('rejects renaming an environment to "self"', () => {
+      const vault = new EnvironmentVault();
+      vault.addEnvironment('dev');
+      vault.addVersion('dev', { A: '1' });
+      expect(() => vault.renameEnvironment('dev', 'self')).toThrow(/reserved/i);
+    });
+
+    it('blocks a "self" environment through the service (setEnv auto-create)', async () => {
+      await EnvironmentVaultService.createVault(
+        testVaultPath,
+        testPassword,
+        new EnvironmentVault().toJSON()
+      );
+      const written = fsMock.writeJSON.mock.calls[0][1];
+      fsMock.pathExists.mockResolvedValue(true);
+      fsMock.readJSON.mockResolvedValue(written);
+
+      const result = await EnvironmentVaultService.setEnv(
+        testVaultPath,
+        testPassword,
+        'self',
+        'KEY',
+        'val'
+      );
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/reserved/i);
+    });
+  });
+
   describe('init', () => {
     it('should initialize empty vault when no environments provided', async () => {
       const result = await EnvironmentVaultService.init({

--- a/src/__tests__/electron/services/EnvironmentVaultService.test.js
+++ b/src/__tests__/electron/services/EnvironmentVaultService.test.js
@@ -354,6 +354,118 @@ describe('EnvironmentVaultService', () => {
     });
   });
 
+  describe('saveVault backup + atomic write', () => {
+    it('backs up the previous file then writes via a temp file + rename', async () => {
+      fsMock.pathExists.mockResolvedValue(true); // an existing vault to preserve
+      const vault = createPopulatedVault(testEnvName, { KEY: 'value' });
+
+      const result = await EnvironmentVaultService.saveVault(
+        testVaultPath,
+        testPassword,
+        vault
+      );
+
+      expect(result.success).toBe(true);
+      expect(fsMock.copy).toHaveBeenCalledWith(
+        testVaultPath,
+        `${testVaultPath}.bak`,
+        { overwrite: true }
+      );
+      expect(fsMock.writeJSON).toHaveBeenCalledWith(
+        `${testVaultPath}.tmp`,
+        expect.objectContaining({ type: 'environment-vault' }),
+        { spaces: 2 }
+      );
+      expect(fsMock.move).toHaveBeenCalledWith(
+        `${testVaultPath}.tmp`,
+        testVaultPath,
+        { overwrite: true }
+      );
+    });
+
+    it('skips the backup when no vault exists yet', async () => {
+      fsMock.pathExists.mockResolvedValue(false);
+
+      const result = await EnvironmentVaultService.saveVault(
+        testVaultPath,
+        testPassword,
+        new EnvironmentVault()
+      );
+
+      expect(result.success).toBe(true);
+      expect(fsMock.copy).not.toHaveBeenCalled();
+    });
+
+    it('leaves the original intact when the atomic write fails', async () => {
+      fsMock.pathExists.mockResolvedValue(true);
+      fsMock.writeJSON.mockRejectedValue(new Error('Disk full'));
+
+      const result = await EnvironmentVaultService.saveVault(
+        testVaultPath,
+        testPassword,
+        new EnvironmentVault()
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Disk full');
+      // The temp file never finished, so it was never renamed over the target.
+      expect(fsMock.move).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('setExtends', () => {
+    async function seed(vault) {
+      await EnvironmentVaultService.createVault(
+        testVaultPath,
+        testPassword,
+        vault.toJSON()
+      );
+      const written = fsMock.writeJSON.mock.calls[0][1];
+      fsMock.pathExists.mockResolvedValue(true);
+      fsMock.readJSON.mockResolvedValue(written);
+    }
+
+    it('sets and persists the parent of an environment', async () => {
+      const vault = new EnvironmentVault();
+      vault.addEnvironment('base');
+      vault.addVersion('base', { PORT: '3000' });
+      vault.addEnvironment('staging');
+      vault.addVersion('staging', { API_URL: 'x' });
+      await seed(vault);
+
+      const result = await EnvironmentVaultService.setExtends(
+        testVaultPath,
+        testPassword,
+        'staging',
+        'base'
+      );
+      expect(result.success).toBe(true);
+
+      fsMock.readJSON.mockResolvedValue(fsMock.writeJSON.mock.calls[1][1]);
+      const load = await EnvironmentVaultService.loadVault(
+        testVaultPath,
+        testPassword
+      );
+      expect(load.data.environments.staging.extends).toBe('base');
+    });
+
+    it('fails when the parent does not exist', async () => {
+      const vault = new EnvironmentVault();
+      vault.addEnvironment('staging');
+      vault.addVersion('staging', { API_URL: 'x' });
+      await seed(vault);
+
+      const result = await EnvironmentVaultService.setExtends(
+        testVaultPath,
+        testPassword,
+        'staging',
+        'ghost'
+      );
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/not found/i);
+    });
+  });
+
   describe('init', () => {
     it('should initialize empty vault when no environments provided', async () => {
       const result = await EnvironmentVaultService.init({
@@ -1187,6 +1299,75 @@ describe('EnvironmentVaultService', () => {
       );
 
       expect(result.success).toBe(false);
+    });
+
+    it('aggregates required keys across the extends chain', async () => {
+      const vault = new EnvironmentVault();
+      vault.addEnvironment('base');
+      vault.addVersion('base', { PORT: '3000' }, { required: ['PORT'] });
+      vault.addEnvironment('dev');
+      vault.addVersion('dev', { API_URL: 'x' }, { required: ['API_URL'] });
+      vault.setExtends('dev', 'base');
+      await seed(vault);
+
+      const result = await EnvironmentVaultService.validateEnv(
+        testVaultPath,
+        testPassword,
+        'dev'
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data.requiredCount).toBe(2); // PORT (base) + API_URL (dev)
+      expect(result.data.errors).toEqual([]); // both present after layering
+    });
+
+    it('errors when an inherited required key is missing', async () => {
+      const vault = new EnvironmentVault();
+      vault.addEnvironment('base');
+      vault.addVersion('base', { LOG: 'info' }, { required: ['DB_URL'] });
+      vault.addEnvironment('dev');
+      vault.addVersion('dev', { API_URL: 'x' });
+      vault.setExtends('dev', 'base');
+      await seed(vault);
+
+      const result = await EnvironmentVaultService.validateEnv(
+        testVaultPath,
+        testPassword,
+        'dev'
+      );
+
+      expect(result.data.errors).toContain('Missing required key: DB_URL');
+    });
+
+    it('reports an unresolved template reference as an error', async () => {
+      await seed(createPopulatedVault(testEnvName, { X: '{{env:ghost/Y}}' }));
+
+      const result = await EnvironmentVaultService.validateEnv(
+        testVaultPath,
+        testPassword,
+        testEnvName
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data.errors.some((e) => /not found/i.test(e))).toBe(true);
+    });
+
+    it('warns on a secret-looking value in a non-required key', async () => {
+      await seed(
+        createPopulatedVault(testEnvName, {
+          TOKEN: 'sk_live_abcdef0123456789',
+        })
+      );
+
+      const result = await EnvironmentVaultService.validateEnv(
+        testVaultPath,
+        testPassword,
+        testEnvName
+      );
+
+      expect(
+        result.data.warnings.some((w) => /secret|private key|token/i.test(w))
+      ).toBe(true);
     });
   });
 });

--- a/src/electron/models/EnvironmentVault.js
+++ b/src/electron/models/EnvironmentVault.js
@@ -82,6 +82,26 @@ export class EnvironmentVault {
     this.updated = new Date().toISOString();
   }
 
+  setExtends(name, parent) {
+    const env = this.#getEnv(name);
+
+    if (parent === null || parent === undefined) {
+      env.extends = null;
+      this.updated = new Date().toISOString();
+      return;
+    }
+
+    if (parent === name) {
+      throw new Error(`Environment '${name}' cannot extend itself`);
+    }
+    if (!this.environments[parent]) {
+      throw new Error(`Environment '${parent}' not found`);
+    }
+
+    env.extends = parent;
+    this.updated = new Date().toISOString();
+  }
+
   #getEnv(name) {
     const env = this.environments[name];
     if (!env) {

--- a/src/electron/models/EnvironmentVault.js
+++ b/src/electron/models/EnvironmentVault.js
@@ -1,3 +1,17 @@
+/**
+ * Environment names that cannot be used because they collide with reserved
+ * template-reference keywords. `{{env:self/KEY}}` always means "this
+ * environment", so an environment literally named `self` would be
+ * unreferenceable. Compared case-insensitively.
+ */
+const RESERVED_ENV_NAMES = new Set(['self']);
+
+function assertNameAllowed(name) {
+  if (RESERVED_ENV_NAMES.has(String(name).toLowerCase())) {
+    throw new Error(`Environment name '${name}' is reserved`);
+  }
+}
+
 export class EnvironmentVault {
   constructor({
     vaultVersion = 1,
@@ -48,6 +62,7 @@ export class EnvironmentVault {
   }
 
   addEnvironment(name, { description = '' } = {}) {
+    assertNameAllowed(name);
     if (this.environments[name]) {
       throw new Error(`Environment '${name}' already exists`);
     }
@@ -72,6 +87,7 @@ export class EnvironmentVault {
     if (!this.environments[oldName]) {
       throw new Error(`Environment '${oldName}' not found`);
     }
+    assertNameAllowed(newName);
     if (this.environments[newName]) {
       throw new Error(`Environment '${newName}' already exists`);
     }

--- a/src/electron/services/EnvironmentResolver.js
+++ b/src/electron/services/EnvironmentResolver.js
@@ -1,0 +1,133 @@
+/**
+ * Read-time resolution of environment values: `extends` layering (SPEC §9)
+ * followed by `{{env:name/KEY}}` template references (SPEC §8).
+ *
+ * Pure logic — no I/O, no crypto. Operates on an in-memory `EnvironmentVault`
+ * instance and throws on any unresolvable input (missing env/key, cycles, depth
+ * overflow). Service callers convert these throws into `{ success, error }`.
+ *
+ * Stored values keep their `{{...}}` tokens verbatim; resolution happens only
+ * when a value is consumed (`run`, `export`, `get`, `diff`, `validate`).
+ */
+
+/** `{{env:SRC/KEY}}` where SRC is an env name or `_self`. Segments per §8.1. */
+const REF_RE = /\{\{\s*env:([A-Za-z0-9._-]+)\/([A-Za-z0-9._-]+)\s*\}\}/g;
+
+/** Max `extends` chain length (§9.2) and max template recursion depth (§8.3). */
+const MAX_DEPTH = 5;
+
+export class EnvironmentResolver {
+  constructor(vault) {
+    this.vault = vault;
+  }
+
+  /**
+   * The `extends` chain for an environment, child-first:
+   * `[name, parent, grandparent, ...]`. Throws on a missing link, a cycle, or
+   * a chain longer than MAX_DEPTH.
+   */
+  #extendsChain(name) {
+    const chain = [];
+    const seen = new Set();
+    let current = name;
+
+    while (current != null) {
+      if (!this.vault.environments[current]) {
+        throw new Error(`Environment '${current}' not found`);
+      }
+      if (seen.has(current)) {
+        throw new Error(
+          `Circular extends chain detected at environment '${current}'`
+        );
+      }
+      seen.add(current);
+      chain.push(current);
+      if (chain.length > MAX_DEPTH) {
+        throw new Error(
+          `Extends chain for '${name}' exceeded max depth of ${MAX_DEPTH}`
+        );
+      }
+      current = this.vault.environments[current].extends || null;
+    }
+
+    return chain;
+  }
+
+  /** Layered vars (extends merge, child overrides), WITHOUT template resolution. */
+  #layeredVars(name) {
+    const chain = this.#extendsChain(name);
+    const merged = {};
+    // Apply ancestor-first so the child wins on key collisions.
+    for (let i = chain.length - 1; i >= 0; i--) {
+      const active = this.vault.getActiveVersion(chain[i]);
+      if (active) Object.assign(merged, active.vars);
+    }
+    return merged;
+  }
+
+  /**
+   * Resolve every `{{env:.../...}}` in a single value string. `selfEnv` is the
+   * environment the value belongs to (the target of `_self`). `visited` holds
+   * the ref keys currently on the resolution stack for cycle detection.
+   */
+  #resolveString(value, selfEnv, visited, depth) {
+    if (typeof value !== 'string') return value;
+    if (depth > MAX_DEPTH) {
+      throw new Error(
+        `Template reference resolution exceeded max depth of ${MAX_DEPTH}`
+      );
+    }
+
+    return value.replace(REF_RE, (_match, src, key) => {
+      const targetEnv = src === '_self' ? selfEnv : src;
+      const refKey = `env:${targetEnv}/${key}`;
+
+      if (visited.has(refKey)) {
+        throw new Error(`Circular reference detected: {{${refKey}}}`);
+      }
+
+      const layered = this.#layeredVars(targetEnv); // throws if env missing
+      if (!(key in layered)) {
+        throw new Error(`Key '${key}' not found in environment '${targetEnv}'`);
+      }
+
+      const nextVisited = new Set(visited).add(refKey);
+      return this.#resolveString(
+        layered[key],
+        targetEnv,
+        nextVisited,
+        depth + 1
+      );
+    });
+  }
+
+  /** Fully resolved vars for an environment: layering then template refs. */
+  resolveEnvironment(name) {
+    const layered = this.#layeredVars(name);
+    const resolved = {};
+    for (const key of Object.keys(layered)) {
+      resolved[key] = this.#resolveString(layered[key], name, new Set(), 0);
+    }
+    return resolved;
+  }
+
+  /** Resolve a single key within an environment (used by `get`). */
+  resolveValue(name, key) {
+    const layered = this.#layeredVars(name);
+    if (!(key in layered)) {
+      throw new Error(`Key '${key}' not found in environment '${name}'`);
+    }
+    return this.#resolveString(layered[key], name, new Set(), 0);
+  }
+
+  /** Union of `required` keys across the whole extends chain (§9.5), deduped. */
+  aggregateRequired(name) {
+    const chain = this.#extendsChain(name);
+    const required = new Set();
+    for (const envName of chain) {
+      const active = this.vault.getActiveVersion(envName);
+      if (active) for (const k of active.required) required.add(k);
+    }
+    return [...required];
+  }
+}

--- a/src/electron/services/EnvironmentResolver.js
+++ b/src/electron/services/EnvironmentResolver.js
@@ -10,7 +10,7 @@
  * when a value is consumed (`run`, `export`, `get`, `diff`, `validate`).
  */
 
-/** `{{env:SRC/KEY}}` where SRC is an env name or `_self`. Segments per §8.1. */
+/** `{{env:SRC/KEY}}` where SRC is an env name or `self`. Segments per §8.1. */
 const REF_RE = /\{\{\s*env:([A-Za-z0-9._-]+)\/([A-Za-z0-9._-]+)\s*\}\}/g;
 
 /** Max `extends` chain length (§9.2) and max template recursion depth (§8.3). */
@@ -67,7 +67,7 @@ export class EnvironmentResolver {
 
   /**
    * Resolve every `{{env:.../...}}` in a single value string. `selfEnv` is the
-   * environment the value belongs to (the target of `_self`). `visited` holds
+   * environment the value belongs to (the target of `self`). `visited` holds
    * the ref keys currently on the resolution stack for cycle detection.
    */
   #resolveString(value, selfEnv, visited, depth) {
@@ -79,7 +79,7 @@ export class EnvironmentResolver {
     }
 
     return value.replace(REF_RE, (_match, src, key) => {
-      const targetEnv = src === '_self' ? selfEnv : src;
+      const targetEnv = src === 'self' ? selfEnv : src;
       const refKey = `env:${targetEnv}/${key}`;
 
       if (visited.has(refKey)) {

--- a/src/electron/services/EnvironmentVaultService.js
+++ b/src/electron/services/EnvironmentVaultService.js
@@ -2,7 +2,15 @@ import fs from 'fs-extra';
 import path from 'path';
 
 import { CryptographyService } from './CryptographyService.js';
+import { EnvironmentResolver } from './EnvironmentResolver.js';
 import { EnvironmentVault } from '../models/EnvironmentVault.js';
+
+/**
+ * Heuristic patterns for values that look like secrets accidentally left in a
+ * non-required (and likely non-sensitive) variable (SPEC §10.1). Warning-only.
+ */
+const SUSPICIOUS_VALUE_RE =
+  /-----BEGIN |sk_live_|AKIA[0-9A-Z]{16}|[0-9a-f]{64,}/;
 import { validatePasswordStrength } from '../utils/passwordValidation.js';
 import { getAppDataPath, getEnvsDir } from '../utils/appPaths.js';
 
@@ -25,8 +33,8 @@ export class EnvironmentVaultService {
     return resolvePath(this.getEnvsDir(), `${name}.env.vault`);
   }
 
-  static getBackupPath(name) {
-    return resolvePath(this.getEnvsDir(), `${name}.env.vault.bak`);
+  static getBackupPath(vaultPath) {
+    return `${vaultPath}.bak`;
   }
 
   static findGitRoot(startDir) {
@@ -204,7 +212,20 @@ export class EnvironmentVaultService {
       };
 
       await fs.ensureDir(path.dirname(vaultPath));
-      await fs.writeJSON(vaultPath, vaultFile, { spaces: 2 });
+
+      // Preserve the previous good state, then write atomically: the new
+      // content lands in a temp file and is renamed over the target only once
+      // fully written, so a crash mid-write can never corrupt the vault, and
+      // `<path>.bak` always holds the last good copy for manual recovery.
+      if (await fs.pathExists(vaultPath)) {
+        await fs.copy(vaultPath, this.getBackupPath(vaultPath), {
+          overwrite: true,
+        });
+      }
+
+      const tmpPath = `${vaultPath}.tmp`;
+      await fs.writeJSON(tmpPath, vaultFile, { spaces: 2 });
+      await fs.move(tmpPath, vaultPath, { overwrite: true });
 
       return { success: true };
     } catch (error) {
@@ -305,23 +326,12 @@ export class EnvironmentVaultService {
 
     try {
       const vault = loadResult.data;
-      const activeVersion = vault.getActiveVersion(envName);
+      const resolver = new EnvironmentResolver(vault);
+      // Resolves layering + template refs; throws if the key is absent (after
+      // inheritance) or a reference cannot be resolved.
+      const value = resolver.resolveValue(envName, key);
 
-      if (!activeVersion) {
-        return {
-          success: false,
-          error: `Environment '${envName}' has no versions`,
-        };
-      }
-
-      if (!(key in activeVersion.vars)) {
-        return {
-          success: false,
-          error: `Key '${key}' not found in environment '${envName}'`,
-        };
-      }
-
-      return { success: true, data: { key, value: activeVersion.vars[key] } };
+      return { success: true, data: { key, value } };
     } catch (error) {
       return { success: false, error: error.message };
     }
@@ -430,7 +440,30 @@ export class EnvironmentVaultService {
 
     try {
       const vault = loadResult.data;
-      vault.removeEnvironment(envName);
+      vault.removeEnvironment(envName); // throws if the environment is missing
+
+      // Deleting an environment discards its entire version history, so keep a
+      // timestamped snapshot of the pre-delete vault alongside the rolling .bak.
+      if (await fs.pathExists(vaultPath)) {
+        const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+        await fs.copy(vaultPath, `${vaultPath}.deleted.${stamp}`, {
+          overwrite: true,
+        });
+      }
+
+      return this.saveVault(vaultPath, password, vault);
+    } catch (error) {
+      return { success: false, error: error.message };
+    }
+  }
+
+  static async setExtends(vaultPath, password, envName, parent) {
+    const loadResult = await this.loadVault(vaultPath, password);
+    if (!loadResult.success) return loadResult;
+
+    try {
+      const vault = loadResult.data;
+      vault.setExtends(envName, parent);
       return this.saveVault(vaultPath, password, vault);
     } catch (error) {
       return { success: false, error: error.message };
@@ -485,8 +518,12 @@ export class EnvironmentVaultService {
     try {
       const vault = loadResult.data;
       const activeVersion = vault.getActiveVersion(envName);
+      const resolver = new EnvironmentResolver(vault);
+      // Resolve layering + template refs; a broken reference throws and is
+      // surfaced as an error below (also covers `run`, which calls this).
+      const vars = resolver.resolveEnvironment(envName);
 
-      if (!activeVersion) {
+      if (!activeVersion && Object.keys(vars).length === 0) {
         return {
           success: false,
           error: `Environment '${envName}' has no versions`,
@@ -494,10 +531,10 @@ export class EnvironmentVaultService {
       }
 
       if (format === 'json') {
-        return { success: true, data: activeVersion.vars };
+        return { success: true, data: vars };
       }
 
-      const lines = Object.entries(activeVersion.vars).map(
+      const lines = Object.entries(vars).map(
         ([key, value]) => `${key}=${value}`
       );
 
@@ -613,16 +650,21 @@ export class EnvironmentVaultService {
         };
       }
 
-      const keysA = new Set(Object.keys(versionA.vars));
-      const keysB = new Set(Object.keys(versionB.vars));
+      // Compare the resolved (layered + template-resolved) views (SPEC §6.3).
+      const resolver = new EnvironmentResolver(vault);
+      const varsA = resolver.resolveEnvironment(envA);
+      const varsB = resolver.resolveEnvironment(envB);
+
+      const keysA = new Set(Object.keys(varsA));
+      const keysB = new Set(Object.keys(varsB));
 
       const added = [...keysB].filter((k) => !keysA.has(k));
       const removed = [...keysA].filter((k) => !keysB.has(k));
       const changed = [...keysA].filter(
-        (k) => keysB.has(k) && versionA.vars[k] !== versionB.vars[k]
+        (k) => keysB.has(k) && varsA[k] !== varsB[k]
       );
       const unchanged = [...keysA].filter(
-        (k) => keysB.has(k) && versionA.vars[k] === versionB.vars[k]
+        (k) => keysB.has(k) && varsA[k] === varsB[k]
       );
 
       return {
@@ -640,19 +682,34 @@ export class EnvironmentVaultService {
 
     try {
       const vault = loadResult.data;
-      // Throws if the environment does not exist; null if it has no versions.
+      // Throws if the environment does not exist.
       const activeVersion = vault.getActiveVersion(envName);
-      const vars = activeVersion ? activeVersion.vars : {};
-      const required = activeVersion ? activeVersion.required : [];
 
       const errors = [];
       const warnings = [];
 
-      for (const key of required) {
-        if (!(key in vars)) {
-          errors.push(`Missing required key: ${key}`);
-        } else if (vars[key] === '' || vars[key] == null) {
-          errors.push(`Required key is empty: ${key}`);
+      // Resolve layering + template refs first. Any resolution failure
+      // (missing ref, cycle, depth overflow, broken extends) is recorded as a
+      // validation error instead of crashing the command.
+      const resolver = new EnvironmentResolver(vault);
+      let vars = activeVersion ? activeVersion.vars : {};
+      let required = [];
+      let resolved = false;
+      try {
+        vars = resolver.resolveEnvironment(envName);
+        required = resolver.aggregateRequired(envName);
+        resolved = true;
+      } catch (err) {
+        errors.push(err.message);
+      }
+
+      if (resolved) {
+        for (const key of required) {
+          if (!(key in vars)) {
+            errors.push(`Missing required key: ${key}`);
+          } else if (vars[key] === '' || vars[key] == null) {
+            errors.push(`Required key is empty: ${key}`);
+          }
         }
       }
 
@@ -663,6 +720,15 @@ export class EnvironmentVaultService {
         if (!/^[A-Z_][A-Z0-9_]*$/.test(key)) {
           warnings.push(
             `Non-standard key name: "${key}" (expected UPPER_CASE)`
+          );
+        }
+        if (
+          typeof value === 'string' &&
+          !required.includes(key) &&
+          SUSPICIOUS_VALUE_RE.test(value)
+        ) {
+          warnings.push(
+            `Possible secret in non-required key "${key}" (looks like a private key or live token)`
           );
         }
       }

--- a/src/electron/services/EnvironmentVaultService.js
+++ b/src/electron/services/EnvironmentVaultService.js
@@ -288,36 +288,44 @@ export class EnvironmentVaultService {
     const loadResult = await this.loadVault(vaultPath, password);
     if (!loadResult.success) return loadResult;
 
-    const vault = loadResult.data;
+    try {
+      const vault = loadResult.data;
 
-    if (!vault.listEnvironmentNames().includes(envName)) {
-      vault.addEnvironment(envName);
+      if (!vault.listEnvironmentNames().includes(envName)) {
+        vault.addEnvironment(envName); // throws on a reserved name
+      }
+
+      const activeVersion = vault.getActiveVersion(envName);
+
+      const nonSensitive = activeVersion ? [...activeVersion.nonSensitive] : [];
+      const required = activeVersion ? [...activeVersion.required] : [];
+
+      if (isPublic && !nonSensitive.includes(key)) {
+        nonSensitive.push(key);
+      } else if (!isPublic) {
+        const idx = nonSensitive.indexOf(key);
+        if (idx !== -1) nonSensitive.splice(idx, 1);
+      }
+
+      // --required is additive: marking a key required persists it, and updating
+      // the value later (without the flag) does not silently un-require it.
+      if (isRequired && !required.includes(key)) {
+        required.push(key);
+      }
+
+      const currentVars = activeVersion ? { ...activeVersion.vars } : {};
+      currentVars[key] = value;
+
+      vault.addVersion(envName, currentVars, {
+        nonSensitive,
+        required,
+        message,
+      });
+
+      return this.saveVault(vaultPath, password, vault);
+    } catch (error) {
+      return { success: false, error: error.message };
     }
-
-    const activeVersion = vault.getActiveVersion(envName);
-
-    const nonSensitive = activeVersion ? [...activeVersion.nonSensitive] : [];
-    const required = activeVersion ? [...activeVersion.required] : [];
-
-    if (isPublic && !nonSensitive.includes(key)) {
-      nonSensitive.push(key);
-    } else if (!isPublic) {
-      const idx = nonSensitive.indexOf(key);
-      if (idx !== -1) nonSensitive.splice(idx, 1);
-    }
-
-    // --required is additive: marking a key required persists it, and updating
-    // the value later (without the flag) does not silently un-require it.
-    if (isRequired && !required.includes(key)) {
-      required.push(key);
-    }
-
-    const currentVars = activeVersion ? { ...activeVersion.vars } : {};
-    currentVars[key] = value;
-
-    vault.addVersion(envName, currentVars, { nonSensitive, required, message });
-
-    return this.saveVault(vaultPath, password, vault);
   }
 
   static async getEnv(vaultPath, password, envName, key) {


### PR DESCRIPTION
## Summary

- v1.5 Composition marked ✅ delivered (resolver: extends layering +
  {{env:name/KEY}}/{{env:self/KEY}} refs + full validation engine), plus the
  .bak/atomic-write, .deleted.<ts> snapshot, and export-json fix shipped with it.
- Add a status legend and per-milestone Status lines; mark v0.5 ✅, v1.0 ✅ with
  two ◑ hardening follow-ups (temp-file cleanup passes/orphan-scan, error codes),
  v2.0/2.5/3.0 ☐ not started.
- Reflect §15 open-question status (Q2 resolved, Q4 partial; Q1/Q5 still open).
- Reserve `self` as an env name (§4.5) and switch §8 self-ref to {{env:self/KEY}}.
- Bump header to "v1.5 delivered · Revision 6" and add changelog row 6.