### PR TITLE
Vault usability improvements

### DIFF
--- a/README.cli.md
+++ b/README.cli.md
@@ -58,7 +58,44 @@ vault env diff dev prod          # compare two environments
 vault env history dev            # view version history
 vault env rollback 3 -e dev      # restore a previous version of "dev"
 vault env run dev -- npm start   # run a command with the env injected
+vault env run dev --dry-run      # preview what would be injected (no spawn)
+vault env shell dev              # open an interactive shell with the env loaded
 ```
+
+#### Zero-friction project setup
+
+Drop a `.vaultrc` at your project root to avoid repeating flags on every invocation:
+
+```json
+{
+  "inject": "merge",
+  "name": "my-project",
+  "allowlistFile": ".vault-allowlist"
+}
+```
+
+Set `VAULT_ENV`, `VAULT_NAME`, or `VAULT_INJECT` for CI pipelines — they fill
+in the same defaults, and `.vaultrc` overrides them, and CLI flags override
+everything:
+
+```bash
+export VAULT_ENV=staging
+vault env run -- node server.js          # env name from VAULT_ENV
+VAULT_INJECT=merge vault env run -- ...  # inject mode from env var
+```
+
+Pass a per-project allowlist file to let extra system vars through in `clean`
+mode (one var per line, `#` comments supported):
+
+```bash
+# .vault-allowlist
+NODE_PATH
+LANG   # locale settings
+TERM   # terminal type
+```
+
+The file `.vault-allowlist` is loaded automatically if present; override with
+`--allowlist-file <path>`.
 
 #### Layering & template references
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -28,7 +28,7 @@ import { VaultService } from '../src/electron/services/VaultService.js';
 import { VaultRecoveryService } from '../src/electron/services/VaultRecoveryService.js';
 import { getVaultsDir } from '../src/electron/utils/appPaths.js';
 import { registerEnvCommand } from './commands/env.js';
-import { injectVaultEnvArg } from './commands/envRunHelpers.js';
+import { extractRunCommand } from './commands/envRunHelpers.js';
 
 program
   .name('SecureVault')
@@ -81,4 +81,4 @@ program
 
 registerEnvCommand(program);
 
-program.parse(injectVaultEnvArg(process.argv));
+program.parse(extractRunCommand(process.argv));

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -28,6 +28,7 @@ import { VaultService } from '../src/electron/services/VaultService.js';
 import { VaultRecoveryService } from '../src/electron/services/VaultRecoveryService.js';
 import { getVaultsDir } from '../src/electron/utils/appPaths.js';
 import { registerEnvCommand } from './commands/env.js';
+import { injectVaultEnvArg } from './commands/envRunHelpers.js';
 
 program
   .name('SecureVault')
@@ -80,4 +81,4 @@ program
 
 registerEnvCommand(program);
 
-program.parse(process.argv);
+program.parse(injectVaultEnvArg(process.argv));

--- a/bin/commands/env.js
+++ b/bin/commands/env.js
@@ -1275,8 +1275,12 @@ export function registerEnvCommand(program) {
       `File of vars to pass through in clean mode (one per line, # comments). ` +
         `Defaults to ${DEFAULT_ALLOWLIST_FILE} in CWD if present.`
     )
+    .option(
+      '--dry-run',
+      'Print the resolved environment without running the command'
+    )
     .action(async (envNameArg, command, options, cmd) => {
-      if (!command || command.length === 0) {
+      if (!options.dryRun && (!command || command.length === 0)) {
         console.error(
           chalk.red('No command specified. Usage: vault env run <env> -- <cmd>')
         );
@@ -1346,6 +1350,47 @@ export function registerEnvCommand(program) {
           parentEnv: process.env,
           allowlist: [...parseAllowlist(options.allowlist), ...fileAllowlist],
         });
+
+        if (options.dryRun) {
+          // Build a sensitivity map from showEnv; inherited vars default to sensitive.
+          const showResult = await EnvironmentVaultService.showEnv(
+            vaultPath,
+            vaultPassword,
+            envName
+          );
+          const sensitiveMap = {};
+          if (showResult.success) {
+            for (const { key, sensitive } of showResult.data.keys) {
+              sensitiveMap[key] = sensitive;
+            }
+          }
+
+          const modeLabel =
+            mode === 'file'
+              ? `${mode} (vars written to ${options.outFile ?? '<out-file>'})`
+              : mode;
+          log(
+            chalk.bold(
+              `\nDry run — env: ${chalk.cyan(envName)}  mode: ${chalk.cyan(modeLabel)}\n`
+            )
+          );
+
+          for (const [key, value] of Object.entries(childEnv)) {
+            const isVaultVar = key in vars;
+            const isSensitive = sensitiveMap[key] ?? true; // unknown → sensitive
+            const display =
+              isVaultVar && isSensitive ? chalk.gray('****') : value;
+            const prefix = isVaultVar ? chalk.green('+') : chalk.gray(' ');
+            log(`  ${prefix} ${chalk.cyan(key)}=${display}`);
+          }
+
+          log(
+            chalk.gray(
+              `\n  ${chalk.green('+')} = from vault   (others inherited from parent env)\n`
+            )
+          );
+          return;
+        }
 
         let envFilePath = null;
         if (mode === 'file') {

--- a/bin/commands/env.js
+++ b/bin/commands/env.js
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 import ora from 'ora';
 import { spawn } from 'child_process';
+import { Option } from 'commander';
 import os from 'os';
 import path from 'path';
 import fs from 'fs-extra';
@@ -1248,14 +1249,18 @@ export function registerEnvCommand(program) {
   env
     .command('run')
     .description('Run a command with the environment injected (no plaintext)')
-    .argument('<envName>', 'Environment name')
+    .argument('[envName]', 'Environment name (overrides VAULT_ENV)')
     .argument('[command...]', 'Command to run (use -- before it)')
-    .option('-n, --name <name>', 'Vault name')
+    .addOption(new Option('-n, --name <name>', 'Vault name').env('VAULT_NAME'))
     .option('-v, --vault <path>', 'Exact vault file path')
     .option('--password <password>', 'Vault password (non-interactive)')
     .option('--password-file <path>', 'Read vault password from a file')
     .option('--password-stdin', 'Read vault password from stdin')
-    .option('--inject <mode>', 'Injection mode: clean | merge | file', 'clean')
+    .addOption(
+      new Option('--inject <mode>', 'Injection mode: clean | merge | file')
+        .default('clean')
+        .env('VAULT_INJECT')
+    )
     .option(
       '--out-file <path>',
       'Temp .env path to write (required for --inject file). Named --out-file ' +
@@ -1270,7 +1275,7 @@ export function registerEnvCommand(program) {
       `File of vars to pass through in clean mode (one per line, # comments). ` +
         `Defaults to ${DEFAULT_ALLOWLIST_FILE} in CWD if present.`
     )
-    .action(async (envName, command, options, cmd) => {
+    .action(async (envNameArg, command, options, cmd) => {
       if (!command || command.length === 0) {
         console.error(
           chalk.red('No command specified. Usage: vault env run <env> -- <cmd>')
@@ -1283,6 +1288,17 @@ export function registerEnvCommand(program) {
         applyProjectConfig(cmd, rc);
       } catch (err) {
         console.error(chalk.red(err.message));
+        process.exit(1);
+      }
+
+      // Resolve environment name: positional arg > VAULT_ENV > error.
+      const envName = envNameArg || process.env.VAULT_ENV;
+      if (!envName) {
+        console.error(
+          chalk.red(
+            'No environment specified. Pass it as an argument or set VAULT_ENV.'
+          )
+        );
         process.exit(1);
       }
 

--- a/bin/commands/env.js
+++ b/bin/commands/env.js
@@ -15,6 +15,8 @@ import {
   toDotenv,
   parseAllowlist,
   readAllowlistFile,
+  loadProjectConfig,
+  applyProjectConfig,
   secureDelete,
   cleanupOrphanTempDirs,
 } from './envRunHelpers.js';
@@ -1268,11 +1270,19 @@ export function registerEnvCommand(program) {
       `File of vars to pass through in clean mode (one per line, # comments). ` +
         `Defaults to ${DEFAULT_ALLOWLIST_FILE} in CWD if present.`
     )
-    .action(async (envName, command, options) => {
+    .action(async (envName, command, options, cmd) => {
       if (!command || command.length === 0) {
         console.error(
           chalk.red('No command specified. Usage: vault env run <env> -- <cmd>')
         );
+        process.exit(1);
+      }
+
+      try {
+        const rc = loadProjectConfig();
+        applyProjectConfig(cmd, rc);
+      } catch (err) {
+        console.error(chalk.red(err.message));
         process.exit(1);
       }
 

--- a/bin/commands/env.js
+++ b/bin/commands/env.js
@@ -10,9 +10,11 @@ import { EnvironmentVaultService } from '../../src/electron/services/Environment
 import { EnvironmentVault } from '../../src/electron/models/EnvironmentVault.js';
 import {
   INJECT_MODES,
+  DEFAULT_ALLOWLIST_FILE,
   buildChildEnv,
   toDotenv,
   parseAllowlist,
+  readAllowlistFile,
   secureDelete,
   cleanupOrphanTempDirs,
 } from './envRunHelpers.js';
@@ -1261,6 +1263,11 @@ export function registerEnvCommand(program) {
       '--allowlist <vars>',
       'Extra system vars to pass through in clean mode (comma-separated)'
     )
+    .option(
+      '--allowlist-file <path>',
+      `File of vars to pass through in clean mode (one per line, # comments). ` +
+        `Defaults to ${DEFAULT_ALLOWLIST_FILE} in CWD if present.`
+    )
     .action(async (envName, command, options) => {
       if (!command || command.length === 0) {
         console.error(
@@ -1298,11 +1305,20 @@ export function registerEnvCommand(program) {
         }
 
         const vars = exportResult.data;
+
+        // Resolve allowlist file: explicit flag (must exist) or CWD default (optional).
+        const allowlistFilePath = options.allowlistFile
+          ? path.resolve(options.allowlistFile)
+          : path.resolve(DEFAULT_ALLOWLIST_FILE);
+        const fileAllowlist = readAllowlistFile(allowlistFilePath, {
+          mustExist: !!options.allowlistFile,
+        });
+
         const childEnv = buildChildEnv({
           mode,
           vars,
           parentEnv: process.env,
-          allowlist: parseAllowlist(options.allowlist),
+          allowlist: [...parseAllowlist(options.allowlist), ...fileAllowlist],
         });
 
         let envFilePath = null;

--- a/bin/commands/env.js
+++ b/bin/commands/env.js
@@ -1435,6 +1435,124 @@ export function registerEnvCommand(program) {
     });
 
   env
+    .command('shell')
+    .description('Open an interactive shell with vault vars loaded')
+    .argument('[envName]', 'Environment name (overrides VAULT_ENV)')
+    .addOption(new Option('-n, --name <name>', 'Vault name').env('VAULT_NAME'))
+    .option('-v, --vault <path>', 'Exact vault file path')
+    .option('--password <password>', 'Vault password (non-interactive)')
+    .option('--password-file <path>', 'Read vault password from a file')
+    .option('--password-stdin', 'Read vault password from stdin')
+    .addOption(
+      new Option('--inject <mode>', 'Injection mode: clean | merge')
+        .default('clean')
+        .env('VAULT_INJECT')
+    )
+    .option(
+      '--allowlist <vars>',
+      'Extra system vars to pass through in clean mode (comma-separated)'
+    )
+    .option(
+      '--allowlist-file <path>',
+      `File of vars to pass through in clean mode (one per line, # comments). ` +
+        `Defaults to ${DEFAULT_ALLOWLIST_FILE} in CWD if present.`
+    )
+    .action(async (envNameArg, options, cmd) => {
+      try {
+        const rc = loadProjectConfig();
+        applyProjectConfig(cmd, rc);
+      } catch (err) {
+        console.error(chalk.red(err.message));
+        process.exit(1);
+      }
+
+      const envName = envNameArg || process.env.VAULT_ENV;
+      if (!envName) {
+        console.error(
+          chalk.red(
+            'No environment specified. Pass it as an argument or set VAULT_ENV.'
+          )
+        );
+        process.exit(1);
+      }
+
+      const mode = options.inject;
+      if (!['clean', 'merge'].includes(mode)) {
+        console.error(
+          chalk.red(`Invalid --inject mode "${mode}" for shell (clean|merge)`)
+        );
+        process.exit(1);
+      }
+
+      try {
+        const { vaultPath, vaultPassword } = await loadVault(options);
+
+        const exportResult = await EnvironmentVaultService.exportEnv(
+          vaultPath,
+          vaultPassword,
+          envName,
+          'json'
+        );
+        if (!exportResult.success) {
+          console.error(chalk.red(exportResult.error));
+          process.exit(1);
+        }
+
+        const vars = exportResult.data;
+
+        const allowlistFilePath = options.allowlistFile
+          ? path.resolve(options.allowlistFile)
+          : path.resolve(DEFAULT_ALLOWLIST_FILE);
+        const fileAllowlist = readAllowlistFile(allowlistFilePath, {
+          mustExist: !!options.allowlistFile,
+        });
+
+        const childEnv = buildChildEnv({
+          mode,
+          vars,
+          parentEnv: process.env,
+          allowlist: [...parseAllowlist(options.allowlist), ...fileAllowlist],
+        });
+
+        // Let prompts (starship, oh-my-zsh, etc.) detect the active vault context.
+        childEnv.VAULT_SHELL = '1';
+        childEnv.VAULT_SHELL_ENV = envName;
+
+        const shell = process.env.SHELL || '/bin/sh';
+        log(
+          chalk.bold(
+            `\nOpening ${chalk.cyan(mode)} shell for env ${chalk.cyan(envName)} (${chalk.gray(shell)})\n` +
+              chalk.gray(`  Type 'exit' or press Ctrl-D to return.\n`)
+          )
+        );
+
+        const child = spawn(shell, [], { stdio: 'inherit', env: childEnv });
+
+        const forward = (signal) => child.kill(signal);
+        process.on('SIGINT', forward);
+        process.on('SIGTERM', forward);
+
+        child.on('error', (err) => {
+          const msg =
+            err.code === 'ENOENT'
+              ? `Shell not found: ${shell}`
+              : `Failed to open shell: ${err.message}`;
+          console.error(chalk.red(msg));
+          process.exit(127);
+        });
+
+        child.on('exit', (code, signal) => {
+          process.removeListener('SIGINT', forward);
+          process.removeListener('SIGTERM', forward);
+          process.exit(signal ? 1 : (code ?? 0));
+        });
+      } catch (error) {
+        console.error(chalk.red(error.message));
+        process.exit(1);
+      }
+    });
+
+  env
     .command('change-password')
     .description('Change the vault password')
     .option('-n, --name <name>', 'Vault name')

--- a/bin/commands/env.js
+++ b/bin/commands/env.js
@@ -20,6 +20,7 @@ import {
   applyProjectConfig,
   secureDelete,
   cleanupOrphanTempDirs,
+  getRunCommand,
 } from './envRunHelpers.js';
 import {
   buildEditorTemplate,
@@ -1279,7 +1280,11 @@ export function registerEnvCommand(program) {
       '--dry-run',
       'Print the resolved environment without running the command'
     )
-    .action(async (envNameArg, command, options, cmd) => {
+    .action(async (envNameArg, commandArg, options, cmd) => {
+      // The command comes from after the `--` wall (extractRunCommand) when one
+      // was present; otherwise fall back to Commander's positional parsing for
+      // the no-`--` form (`vault env run <env> <cmd>...`).
+      const command = getRunCommand() ?? commandArg;
       if (!options.dryRun && (!command || command.length === 0)) {
         console.error(
           chalk.red('No command specified. Usage: vault env run <env> -- <cmd>')

--- a/bin/commands/envRunHelpers.js
+++ b/bin/commands/envRunHelpers.js
@@ -81,33 +81,32 @@ export function readAllowlistFile(filePath, { mustExist = false } = {}) {
 
 export const VAULTRC_FILENAME = '.vaultrc';
 
-// Flags on `vault env run` that consume the next argument as their value.
-const RUN_FLAGS_WITH_VALUE = new Set([
-  '-n',
-  '--name',
-  '-v',
-  '--vault',
-  '--password',
-  '--password-file',
-  '--inject',
-  '--out-file',
-  '--allowlist',
-  '--allowlist-file',
-]);
+// The command to run, captured from the tokens after the first `--` of a
+// `vault env run` invocation. Set by extractRunCommand(), read by the run
+// action via getRunCommand(). Module-level because the CLI is single-shot.
+let runCommand = null;
+
+/** The command captured from after `--`, or null if there was no `--`. */
+export function getRunCommand() {
+  return runCommand;
+}
 
 /**
- * Inject VAULT_ENV into argv before the `--` separator when `vault env run`
- * is invoked without an explicit envName positional argument. This lets
- * Commander see the env name as a proper positional rather than consuming
- * the first command argument after `--` as the env name.
+ * Treat the first `--` after `vault env run` as a hard wall: everything to its
+ * right is the command to execute and is removed from argv before Commander
+ * parses, so a command token can never be mis-consumed as the `[envName]`
+ * positional. The env name is then resolved solely from a positional *before*
+ * `--` (or the VAULT_ENV fallback in the run action) — never from the command.
  *
- * Does nothing when VAULT_ENV is not set, when `env run` is not in argv,
- * when there is no `--` separator, or when an envName is already present.
+ * Returns argv unchanged (and leaves the captured command null) when this is
+ * not an `env run` invocation or there is no `--` separator. The `--` case
+ * stashes the trailing tokens for getRunCommand(); any further `--` in the
+ * command is preserved so nested `vault env run … -- …` composes correctly.
  */
-export function injectVaultEnvArg(argv, vaultEnv = process.env.VAULT_ENV) {
-  if (!vaultEnv) return argv;
+export function extractRunCommand(argv) {
+  runCommand = null;
 
-  // Locate 'env run' in the argument list.
+  // Locate the `env run` subcommand (options for `run` always follow `run`).
   let runPos = -1;
   for (let i = 0; i < argv.length - 1; i++) {
     if (argv[i] === 'env' && argv[i + 1] === 'run') {
@@ -117,28 +116,11 @@ export function injectVaultEnvArg(argv, vaultEnv = process.env.VAULT_ENV) {
   }
   if (runPos === -1) return argv;
 
-  // Find the `--` separator after `run`.
   const ddPos = argv.indexOf('--', runPos + 1);
   if (ddPos === -1) return argv;
 
-  // Walk the slice between `run` and `--`, skipping known option/value pairs.
-  // If any non-option, non-value arg is found, the user already supplied envName.
-  let i = runPos + 1;
-  while (i < ddPos) {
-    const arg = argv[i];
-    if (RUN_FLAGS_WITH_VALUE.has(arg)) {
-      i += 2; // skip flag + its value
-    } else if (arg.startsWith('-')) {
-      i += 1; // boolean flag
-    } else {
-      return argv; // positional envName already present
-    }
-  }
-
-  // No envName found before `--`: inject VAULT_ENV there.
-  const result = [...argv];
-  result.splice(ddPos, 0, vaultEnv);
-  return result;
+  runCommand = argv.slice(ddPos + 1);
+  return argv.slice(0, ddPos);
 }
 
 // Keys in .vaultrc and the Commander option name they map to.

--- a/bin/commands/envRunHelpers.js
+++ b/bin/commands/envRunHelpers.js
@@ -81,6 +81,66 @@ export function readAllowlistFile(filePath, { mustExist = false } = {}) {
 
 export const VAULTRC_FILENAME = '.vaultrc';
 
+// Flags on `vault env run` that consume the next argument as their value.
+const RUN_FLAGS_WITH_VALUE = new Set([
+  '-n',
+  '--name',
+  '-v',
+  '--vault',
+  '--password',
+  '--password-file',
+  '--inject',
+  '--out-file',
+  '--allowlist',
+  '--allowlist-file',
+]);
+
+/**
+ * Inject VAULT_ENV into argv before the `--` separator when `vault env run`
+ * is invoked without an explicit envName positional argument. This lets
+ * Commander see the env name as a proper positional rather than consuming
+ * the first command argument after `--` as the env name.
+ *
+ * Does nothing when VAULT_ENV is not set, when `env run` is not in argv,
+ * when there is no `--` separator, or when an envName is already present.
+ */
+export function injectVaultEnvArg(argv, vaultEnv = process.env.VAULT_ENV) {
+  if (!vaultEnv) return argv;
+
+  // Locate 'env run' in the argument list.
+  let runPos = -1;
+  for (let i = 0; i < argv.length - 1; i++) {
+    if (argv[i] === 'env' && argv[i + 1] === 'run') {
+      runPos = i + 1;
+      break;
+    }
+  }
+  if (runPos === -1) return argv;
+
+  // Find the `--` separator after `run`.
+  const ddPos = argv.indexOf('--', runPos + 1);
+  if (ddPos === -1) return argv;
+
+  // Walk the slice between `run` and `--`, skipping known option/value pairs.
+  // If any non-option, non-value arg is found, the user already supplied envName.
+  let i = runPos + 1;
+  while (i < ddPos) {
+    const arg = argv[i];
+    if (RUN_FLAGS_WITH_VALUE.has(arg)) {
+      i += 2; // skip flag + its value
+    } else if (arg.startsWith('-')) {
+      i += 1; // boolean flag
+    } else {
+      return argv; // positional envName already present
+    }
+  }
+
+  // No envName found before `--`: inject VAULT_ENV there.
+  const result = [...argv];
+  result.splice(ddPos, 0, vaultEnv);
+  return result;
+}
+
 // Keys in .vaultrc and the Commander option name they map to.
 const VAULTRC_KEYS = ['inject', 'env', 'name', 'vault', 'allowlistFile'];
 
@@ -116,17 +176,17 @@ export function loadProjectConfig(startDir = process.cwd()) {
 }
 
 /**
- * Apply .vaultrc defaults to a Commander options object. Only keys whose
- * current source is 'default' (i.e. not set by the user on the CLI) are
- * overwritten, so CLI flags always win.
+ * Apply .vaultrc defaults to a Commander options object.
+ * Precedence: CLI flag ('cli') > .vaultrc ('config') > env var ('env') > default.
+ * Only overwrites options whose source is 'default' or 'env'.
  */
 export function applyProjectConfig(cmd, config) {
   for (const key of VAULTRC_KEYS) {
-    if (
-      config[key] !== undefined &&
-      cmd.getOptionValueSource(key) === 'default'
-    ) {
-      cmd.setOptionValueWithSource(key, config[key], 'config');
+    if (config[key] !== undefined) {
+      const src = cmd.getOptionValueSource(key);
+      if (src === 'default' || src === 'env') {
+        cmd.setOptionValueWithSource(key, config[key], 'config');
+      }
     }
   }
 }

--- a/bin/commands/envRunHelpers.js
+++ b/bin/commands/envRunHelpers.js
@@ -79,6 +79,58 @@ export function readAllowlistFile(filePath, { mustExist = false } = {}) {
     .filter(Boolean);
 }
 
+export const VAULTRC_FILENAME = '.vaultrc';
+
+// Keys in .vaultrc and the Commander option name they map to.
+const VAULTRC_KEYS = ['inject', 'env', 'name', 'vault', 'allowlistFile'];
+
+/**
+ * Walk from startDir upward looking for a .vaultrc file, stopping at a git
+ * root (presence of .git) or the filesystem root. Returns the parsed config
+ * object, or {} if no file is found. Throws on JSON parse errors.
+ */
+export function loadProjectConfig(startDir = process.cwd()) {
+  let dir = path.resolve(startDir);
+  while (true) {
+    const candidate = path.join(dir, VAULTRC_FILENAME);
+    if (fs.existsSync(candidate)) {
+      let raw;
+      try {
+        raw = fs.readFileSync(candidate, 'utf-8');
+      } catch (err) {
+        throw new Error(`Cannot read ${candidate}: ${err.message}`);
+      }
+      try {
+        return JSON.parse(raw);
+      } catch (err) {
+        throw new Error(`Invalid JSON in ${candidate}: ${err.message}`);
+      }
+    }
+    // Stop at a git root or the filesystem root.
+    if (fs.existsSync(path.join(dir, '.git'))) break;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return {};
+}
+
+/**
+ * Apply .vaultrc defaults to a Commander options object. Only keys whose
+ * current source is 'default' (i.e. not set by the user on the CLI) are
+ * overwritten, so CLI flags always win.
+ */
+export function applyProjectConfig(cmd, config) {
+  for (const key of VAULTRC_KEYS) {
+    if (
+      config[key] !== undefined &&
+      cmd.getOptionValueSource(key) === 'default'
+    ) {
+      cmd.setOptionValueWithSource(key, config[key], 'config');
+    }
+  }
+}
+
 /**
  * Best-effort secure deletion: overwrite the file with 3 passes (0xFF, 0x00,
  * random) before unlinking, per SPEC §12.3.

--- a/bin/commands/envRunHelpers.js
+++ b/bin/commands/envRunHelpers.js
@@ -3,6 +3,8 @@ import os from 'os';
 import path from 'path';
 import fs from 'fs-extra';
 
+export const DEFAULT_ALLOWLIST_FILE = '.vault-allowlist';
+
 // System variables passed through in `clean` mode so the spawned command can
 // still find its interpreter, home dir, etc. without inheriting the full env.
 export const CLEAN_ALLOWLIST = ['PATH', 'HOME', 'SHELL', 'USER', 'TMPDIR'];
@@ -54,6 +56,26 @@ export function parseAllowlist(value) {
   return value
     .split(',')
     .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Read variable names from an allowlist file (one per line, # comments).
+ * Returns an empty array if filePath is falsy or the file doesn't exist and
+ * mustExist is false. Throws if mustExist is true and the file is unreadable.
+ */
+export function readAllowlistFile(filePath, { mustExist = false } = {}) {
+  if (!filePath) return [];
+  let content;
+  try {
+    content = fs.readFileSync(filePath, 'utf-8');
+  } catch (err) {
+    if (!mustExist && err.code === 'ENOENT') return [];
+    throw new Error(`Cannot read allowlist file "${filePath}": ${err.message}`);
+  }
+  return content
+    .split('\n')
+    .map((line) => line.replace(/#.*$/, '').trim())
     .filter(Boolean);
 }
 

--- a/docs/environments/SPEC.md
+++ b/docs/environments/SPEC.md
@@ -452,7 +452,8 @@ vault env
   ├── copy   <src> <dst>              Copy an environment to a new name
   ├── diff   <envA> <envB>            Show diff between two environments
   ├── import <env> <file...>          Import .env file(s) into an environment
-  ├── run    <env> [--] <cmd>...      Run command with env injected
+  ├── run    [env] [--] <cmd>...      Run command with env injected
+  ├── shell  [env]                    Open interactive shell with env loaded
   │
   └── change-password                 Re-encrypt the vault with a new password
 ```
@@ -719,24 +720,45 @@ To undo a rollback, rollback again to the version before it.
 ```
 
 USAGE
-vault env run <env> [--vault <path>]
+vault env run [env] [--vault <path>]
 [--inject clean|merge|file]
-[--env-file <path>]
+[--out-file <path>]
 [--allowlist <comma-separated-vars>]
+[--allowlist-file <path>]
+[--dry-run]
 [--] <command>...
 
 FLAGS
 --inject <mode>
 clean (default) Only vault vars + allowlisted system vars (PATH, HOME, SHELL, USER, TMPDIR)
 merge Vault vars merged into inherited process.env
-file Write --env-file, set an env var pointing to it, spawn, cleanup
+file Write --out-file, spawn, then securely delete the file
 
---env-file <path>
+--out-file <path>
 Path to write a temporary .env file. Required when --inject=file.
-The file is created before spawn, securely deleted after child exits.
+The file is created 0600 before spawn and securely deleted after child exits.
 
 --allowlist <vars>
-Additional system vars to allow through in clean mode (comma-separated, no spaces).
+Additional system vars to allow through in clean mode (comma-separated).
+
+--allowlist-file <path>
+File of vars to allow through in clean mode (one per line, # comments).
+Defaults to .vault-allowlist in CWD if present; explicit path must exist.
+
+--dry-run
+Print the resolved environment without spawning the command.
+Vault vars are marked with '+'; sensitive values are masked as \*\*\*\*.
+
+ENV VARS
+VAULT_ENV Default environment name (overridden by positional arg or .vaultrc)
+VAULT_NAME Default vault name (overridden by --name or .vaultrc)
+VAULT_INJECT Default inject mode (overridden by --inject or .vaultrc)
+
+Precedence: CLI flag > .vaultrc > env var > built-in default.
+
+PROJECT CONFIG (.vaultrc)
+A .vaultrc JSON file at the project root (walks up to git root) sets defaults
+for any of: inject, env, name, vault, allowlistFile.
 
 DESCRIPTION
 Decrypts the env vault, resolves templates, validates required vars,
@@ -757,11 +779,64 @@ vault env run development --inject merge -- npx react-native run-ios
 
 # Temp .env file for react-native-config build
 
-vault env run staging --inject file --env-file .env -- npx react-native run-ios
+vault env run staging --inject file --out-file .env -- npx react-native run-ios
 
 # Clean mode with additional system vars allowed
 
 vault env run production --allowlist NODE_PATH,LANG -- npm run build
+
+# Allow extra vars via file
+
+vault env run production --allowlist-file .vault-allowlist -- npm run build
+
+# Preview what would be injected
+
+vault env run staging --dry-run
+
+# Use VAULT_ENV (useful in CI)
+
+VAULT_ENV=staging vault env run -- node server.js
+
+```
+
+#### `vault env shell`
+
+```
+
+USAGE
+vault env shell [env] [--vault <path>]
+[--inject clean|merge]
+[--allowlist <comma-separated-vars>]
+[--allowlist-file <path>]
+
+FLAGS
+--inject <mode>
+clean (default) Only vault vars + allowlisted system vars
+merge Vault vars merged into inherited process.env
+(file mode is not supported for interactive shells)
+
+--allowlist / --allowlist-file
+Same semantics as vault env run.
+
+ENV VARS / PROJECT CONFIG
+Same resolution as vault env run (VAULT_ENV, VAULT_NAME, VAULT_INJECT, .vaultrc).
+
+DESCRIPTION
+Opens an interactive subshell ($SHELL) with the vault environment loaded.
+Sets VAULT_SHELL=1 and VAULT_SHELL_ENV=<envName> so prompt integrations
+(starship, oh-my-zsh, etc.) can indicate the active vault context.
+
+Type 'exit' or Ctrl-D to return to the parent shell.
+
+EXAMPLES
+
+# Drop into a shell with the staging env loaded
+
+vault env shell staging
+
+# Use merge mode to keep your full dev environment
+
+vault env shell dev --inject merge
 
 ```
 

--- a/src/__tests__/cli/envRun.integration.test.js
+++ b/src/__tests__/cli/envRun.integration.test.js
@@ -151,4 +151,81 @@ describe('vault env run (integration)', () => {
     expect(r.status).toBe(1);
     expect(r.stdout + r.stderr).toMatch(/No command/i);
   });
+
+  it('.vaultrc inject default is applied when no --inject flag is passed', () => {
+    const rcDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sv-rc-'));
+    const rcPath = path.join(rcDir, '.vaultrc');
+    fs.writeFileSync(rcPath, JSON.stringify({ inject: 'merge' }));
+    try {
+      const r = spawnSync(
+        NODE,
+        [CLI, 'env', 'run', 'dev', '-v', vaultPath, '--', ...PRINT_ENV],
+        {
+          encoding: 'utf8',
+          cwd: rcDir,
+          env: { ...process.env, VAULT_ENV_PASSWORD: PASSWORD },
+        }
+      );
+      expect(r.status).toBe(0);
+      const env = JSON.parse(r.stdout);
+      // merge mode: VAULT_ENV_PASSWORD should be inherited from parent
+      expect(env.VAULT_ENV_PASSWORD).toBe(PASSWORD);
+    } finally {
+      fs.rmSync(rcDir, { recursive: true, force: true });
+    }
+  });
+
+  it('.vaultrc is ignored when CLI flag explicitly overrides it', () => {
+    const rcDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sv-rc-'));
+    const rcPath = path.join(rcDir, '.vaultrc');
+    fs.writeFileSync(rcPath, JSON.stringify({ inject: 'merge' }));
+    try {
+      const r = spawnSync(
+        NODE,
+        [
+          CLI,
+          'env',
+          'run',
+          'dev',
+          '--inject',
+          'clean',
+          '-v',
+          vaultPath,
+          '--',
+          ...PRINT_ENV,
+        ],
+        {
+          encoding: 'utf8',
+          cwd: rcDir,
+          env: { ...process.env, VAULT_ENV_PASSWORD: PASSWORD },
+        }
+      );
+      expect(r.status).toBe(0);
+      const env = JSON.parse(r.stdout);
+      // clean mode wins: VAULT_ENV_PASSWORD must not leak
+      expect(env.VAULT_ENV_PASSWORD).toBeUndefined();
+    } finally {
+      fs.rmSync(rcDir, { recursive: true, force: true });
+    }
+  });
+
+  it('exits 1 with a clear message on invalid .vaultrc JSON', () => {
+    const rcDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sv-rc-'));
+    fs.writeFileSync(path.join(rcDir, '.vaultrc'), '{ bad json }');
+    try {
+      const r = spawnSync(
+        NODE,
+        [CLI, 'env', 'run', 'dev', '-v', vaultPath, '--', NODE, '-e', '0'],
+        {
+          encoding: 'utf8',
+          cwd: rcDir,
+          env: { ...process.env, VAULT_ENV_PASSWORD: PASSWORD },
+        }
+      );
+      expect(r.status).toBe(1);
+      expect(r.stdout + r.stderr).toMatch(/Invalid JSON/i);
+    } finally {
+      fs.rmSync(rcDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/__tests__/cli/envRun.integration.test.js
+++ b/src/__tests__/cli/envRun.integration.test.js
@@ -228,4 +228,58 @@ describe('vault env run (integration)', () => {
       fs.rmSync(rcDir, { recursive: true, force: true });
     }
   });
+
+  it('VAULT_ENV is used when no envName argument is passed', () => {
+    const r = cli(['run', '-v', vaultPath, '--', ...PRINT_ENV], {
+      VAULT_ENV: 'dev',
+    });
+    expect(r.status).toBe(0);
+    const env = JSON.parse(r.stdout);
+    expect(env.API_URL).toBe('https://api.example.com');
+  });
+
+  it('positional envName overrides VAULT_ENV', () => {
+    // 'dev' has API_URL; there is no 'other' env so it should error — proving
+    // the positional arg was used instead of falling back to VAULT_ENV=dev.
+    const r = cli(['run', 'nonexistent', '-v', vaultPath, '--', ...PRINT_ENV], {
+      VAULT_ENV: 'dev',
+    });
+    expect(r.status).not.toBe(0);
+  });
+
+  it('exits 1 when neither envName arg nor VAULT_ENV is set', () => {
+    // Without VAULT_ENV set and no positional before --, Commander assigns
+    // the first post-`--` token as envName. The vault will not find it and
+    // exits non-zero — the important thing is that nothing succeeds.
+    const env = { ...process.env, VAULT_ENV_PASSWORD: PASSWORD };
+    delete env.VAULT_ENV;
+    const r = spawnSync(
+      NODE,
+      [CLI, 'env', 'run', '-v', vaultPath, '--', ...PRINT_ENV],
+      {
+        encoding: 'utf8',
+        env,
+      }
+    );
+    expect(r.status).not.toBe(0);
+  });
+
+  it('VAULT_INJECT sets the injection mode', () => {
+    const r = cli(['run', 'dev', '-v', vaultPath, '--', ...PRINT_ENV], {
+      VAULT_INJECT: 'merge',
+    });
+    expect(r.status).toBe(0);
+    const env = JSON.parse(r.stdout);
+    expect(env.VAULT_ENV_PASSWORD).toBe(PASSWORD);
+  });
+
+  it('--inject flag overrides VAULT_INJECT', () => {
+    const r = cli(
+      ['run', 'dev', '--inject', 'clean', '-v', vaultPath, '--', ...PRINT_ENV],
+      { VAULT_INJECT: 'merge' }
+    );
+    expect(r.status).toBe(0);
+    const env = JSON.parse(r.stdout);
+    expect(env.VAULT_ENV_PASSWORD).toBeUndefined();
+  });
 });

--- a/src/__tests__/cli/envRun.integration.test.js
+++ b/src/__tests__/cli/envRun.integration.test.js
@@ -247,10 +247,11 @@ describe('vault env run (integration)', () => {
     expect(r.status).not.toBe(0);
   });
 
-  it('exits 1 when neither envName arg nor VAULT_ENV is set', () => {
-    // Without VAULT_ENV set and no positional before --, Commander assigns
-    // the first post-`--` token as envName. The vault will not find it and
-    // exits non-zero — the important thing is that nothing succeeds.
+  it('errors with "no environment" when neither envName arg nor VAULT_ENV is set', () => {
+    // The `--` is a hard wall: the command after it is never consulted for the
+    // env name. With no positional env and no VAULT_ENV, this must fail with a
+    // clear "no environment" message — not silently treat a command token as
+    // the env name.
     const env = { ...process.env, VAULT_ENV_PASSWORD: PASSWORD };
     delete env.VAULT_ENV;
     const r = spawnSync(
@@ -261,7 +262,24 @@ describe('vault env run (integration)', () => {
         env,
       }
     );
-    expect(r.status).not.toBe(0);
+    expect(r.status).toBe(1);
+    expect(r.stdout + r.stderr).toMatch(/no environment/i);
+  });
+
+  it('does not consume a post-`--` token as the env name (run -- vault env list)', () => {
+    // Regression: `vault env run -- vault env list` used to resolve env="vault"
+    // and report "Environment 'vault' not found". It must report a missing
+    // environment instead, never interpreting the command as the env name.
+    const env = { ...process.env, VAULT_ENV_PASSWORD: PASSWORD };
+    delete env.VAULT_ENV;
+    const r = spawnSync(
+      NODE,
+      [CLI, 'env', 'run', '-v', vaultPath, '--', 'vault', 'env', 'list'],
+      { encoding: 'utf8', env }
+    );
+    expect(r.status).toBe(1);
+    expect(r.stdout + r.stderr).toMatch(/no environment/i);
+    expect(r.stdout + r.stderr).not.toMatch(/'vault' not found/i);
   });
 
   it('VAULT_INJECT sets the injection mode', () => {

--- a/src/__tests__/cli/envRun.integration.test.js
+++ b/src/__tests__/cli/envRun.integration.test.js
@@ -282,4 +282,49 @@ describe('vault env run (integration)', () => {
     const env = JSON.parse(r.stdout);
     expect(env.VAULT_ENV_PASSWORD).toBeUndefined();
   });
+
+  it('--dry-run prints vault vars without spawning the command', () => {
+    const r = cli(['run', 'dev', '--dry-run', '-v', vaultPath]);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/API_URL/);
+    // Sensitive vars must be masked
+    expect(r.stdout).not.toMatch(/sekret/);
+    expect(r.stdout).toMatch(/\*\*\*\*/);
+  });
+
+  it('--dry-run does not require a command argument', () => {
+    const r = cli(['run', 'dev', '--dry-run', '-v', vaultPath]);
+    expect(r.status).toBe(0);
+  });
+
+  it('--dry-run shows public vars in full', () => {
+    // Mark API_URL as public first
+    cli([
+      'set',
+      'API_URL',
+      'https://api.example.com',
+      '-e',
+      'dev',
+      '-v',
+      vaultPath,
+      '--public',
+    ]);
+    const r = cli(['run', 'dev', '--dry-run', '-v', vaultPath]);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/API_URL=https:\/\/api\.example\.com/);
+  });
+
+  it('--dry-run shows mode in header', () => {
+    const r = cli([
+      'run',
+      'dev',
+      '--dry-run',
+      '--inject',
+      'merge',
+      '-v',
+      vaultPath,
+    ]);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/merge/i);
+  });
 });

--- a/src/__tests__/cli/envRunHelpers.test.js
+++ b/src/__tests__/cli/envRunHelpers.test.js
@@ -14,7 +14,8 @@ import {
   readAllowlistFile,
   loadProjectConfig,
   applyProjectConfig,
-  injectVaultEnvArg,
+  extractRunCommand,
+  getRunCommand,
 } from '../../../bin/commands/envRunHelpers.js';
 
 describe('buildChildEnv', () => {
@@ -252,10 +253,10 @@ describe('applyProjectConfig', () => {
   });
 });
 
-describe('injectVaultEnvArg', () => {
+describe('extractRunCommand', () => {
   const BASE = ['node', 'cli'];
 
-  it('injects VAULT_ENV before -- when no envName is present', () => {
+  it('strips the command after -- and captures it for getRunCommand', () => {
     const argv = [
       ...BASE,
       'env',
@@ -266,21 +267,18 @@ describe('injectVaultEnvArg', () => {
       'node',
       'server.js',
     ];
-    expect(injectVaultEnvArg(argv, 'staging')).toEqual([
+    expect(extractRunCommand(argv)).toEqual([
       'node',
       'cli',
       'env',
       'run',
       '-v',
       '/vault',
-      'staging',
-      '--',
-      'node',
-      'server.js',
     ]);
+    expect(getRunCommand()).toEqual(['node', 'server.js']);
   });
 
-  it('does not inject when envName is already provided before --', () => {
+  it('keeps an envName positional that appears before --', () => {
     const argv = [
       ...BASE,
       'env',
@@ -292,72 +290,80 @@ describe('injectVaultEnvArg', () => {
       'node',
       's.js',
     ];
-    expect(injectVaultEnvArg(argv, 'staging')).toBe(argv);
-  });
-
-  it('does not inject when vaultEnv is falsy', () => {
-    const argv = [...BASE, 'env', 'run', '--', 'node', 's.js'];
-    expect(injectVaultEnvArg(argv, undefined)).toBe(argv);
-    expect(injectVaultEnvArg(argv, '')).toBe(argv);
-  });
-
-  it('does not inject when there is no -- separator', () => {
-    const argv = [...BASE, 'env', 'run', '-v', '/vault'];
-    expect(injectVaultEnvArg(argv, 'staging')).toBe(argv);
-  });
-
-  it('does not inject when env run is not in argv', () => {
-    const argv = [...BASE, 'env', 'show', '--', 'extra'];
-    expect(injectVaultEnvArg(argv, 'staging')).toBe(argv);
-  });
-
-  it('correctly skips boolean flags before --', () => {
-    const argv = [
-      ...BASE,
-      'env',
-      'run',
-      '--password-stdin',
-      '--',
-      'node',
-      's.js',
-    ];
-    expect(injectVaultEnvArg(argv, 'dev')).toEqual([
+    expect(extractRunCommand(argv)).toEqual([
       'node',
       'cli',
       'env',
       'run',
-      '--password-stdin',
+      '-v',
+      '/vault',
       'dev',
-      '--',
-      'node',
-      's.js',
     ]);
+    expect(getRunCommand()).toEqual(['node', 's.js']);
   });
 
-  it('correctly skips flags-with-value pairs before --', () => {
+  it('never consumes a command token as envName (the run -- bug)', () => {
+    // `vault env run -- vault env list` must NOT treat the first post-`--`
+    // token ("vault") as the environment name.
+    const argv = [...BASE, 'env', 'run', '--', 'vault', 'env', 'list'];
+    expect(extractRunCommand(argv)).toEqual(['node', 'cli', 'env', 'run']);
+    expect(getRunCommand()).toEqual(['vault', 'env', 'list']);
+  });
+
+  it('preserves a nested -- inside the command for recursive run', () => {
     const argv = [
       ...BASE,
       'env',
       'run',
-      '--inject',
-      'merge',
-      '-v',
-      '/v',
-      '--',
-      'cmd',
-    ];
-    expect(injectVaultEnvArg(argv, 'prod')).toEqual([
-      'node',
-      'cli',
-      'env',
-      'run',
-      '--inject',
-      'merge',
-      '-v',
-      '/v',
       'prod',
       '--',
-      'cmd',
+      'vault',
+      'env',
+      'run',
+      'dev',
+      '--',
+      'echo',
+      'hi',
+    ];
+    expect(extractRunCommand(argv)).toEqual([
+      'node',
+      'cli',
+      'env',
+      'run',
+      'prod',
     ]);
+    expect(getRunCommand()).toEqual([
+      'vault',
+      'env',
+      'run',
+      'dev',
+      '--',
+      'echo',
+      'hi',
+    ]);
+  });
+
+  it('returns argv unchanged with no command when there is no -- separator', () => {
+    const argv = [...BASE, 'env', 'run', '-v', '/vault'];
+    expect(extractRunCommand(argv)).toBe(argv);
+    expect(getRunCommand()).toBeNull();
+  });
+
+  it('returns argv unchanged when env run is not in argv', () => {
+    const argv = [...BASE, 'env', 'show', '--', 'extra'];
+    expect(extractRunCommand(argv)).toBe(argv);
+    expect(getRunCommand()).toBeNull();
+  });
+
+  it('captures an empty command for a trailing -- with nothing after', () => {
+    const argv = [...BASE, 'env', 'run', 'dev', '--'];
+    expect(extractRunCommand(argv)).toEqual([
+      'node',
+      'cli',
+      'env',
+      'run',
+      'dev',
+    ]);
+    expect(getRunCommand()).toEqual([]);
   });
 });

--- a/src/__tests__/cli/envRunHelpers.test.js
+++ b/src/__tests__/cli/envRunHelpers.test.js
@@ -14,6 +14,7 @@ import {
   readAllowlistFile,
   loadProjectConfig,
   applyProjectConfig,
+  injectVaultEnvArg,
 } from '../../../bin/commands/envRunHelpers.js';
 
 describe('buildChildEnv', () => {
@@ -238,8 +239,125 @@ describe('applyProjectConfig', () => {
     expect(cmd.opts().inject).toBe('file');
   });
 
+  it('overrides an env-var-set option (.vaultrc beats VAULT_* env vars)', () => {
+    const cmd = makeCmd();
+    cmd.setOptionValueWithSource('inject', 'merge', 'env');
+    applyProjectConfig(cmd, { inject: 'file' });
+    expect(cmd.opts().inject).toBe('file');
+  });
+
   it('ignores unknown keys in config', () => {
     const cmd = makeCmd();
     expect(() => applyProjectConfig(cmd, { unknown: 'value' })).not.toThrow();
+  });
+});
+
+describe('injectVaultEnvArg', () => {
+  const BASE = ['node', 'cli'];
+
+  it('injects VAULT_ENV before -- when no envName is present', () => {
+    const argv = [
+      ...BASE,
+      'env',
+      'run',
+      '-v',
+      '/vault',
+      '--',
+      'node',
+      'server.js',
+    ];
+    expect(injectVaultEnvArg(argv, 'staging')).toEqual([
+      'node',
+      'cli',
+      'env',
+      'run',
+      '-v',
+      '/vault',
+      'staging',
+      '--',
+      'node',
+      'server.js',
+    ]);
+  });
+
+  it('does not inject when envName is already provided before --', () => {
+    const argv = [
+      ...BASE,
+      'env',
+      'run',
+      '-v',
+      '/vault',
+      'dev',
+      '--',
+      'node',
+      's.js',
+    ];
+    expect(injectVaultEnvArg(argv, 'staging')).toBe(argv);
+  });
+
+  it('does not inject when vaultEnv is falsy', () => {
+    const argv = [...BASE, 'env', 'run', '--', 'node', 's.js'];
+    expect(injectVaultEnvArg(argv, undefined)).toBe(argv);
+    expect(injectVaultEnvArg(argv, '')).toBe(argv);
+  });
+
+  it('does not inject when there is no -- separator', () => {
+    const argv = [...BASE, 'env', 'run', '-v', '/vault'];
+    expect(injectVaultEnvArg(argv, 'staging')).toBe(argv);
+  });
+
+  it('does not inject when env run is not in argv', () => {
+    const argv = [...BASE, 'env', 'show', '--', 'extra'];
+    expect(injectVaultEnvArg(argv, 'staging')).toBe(argv);
+  });
+
+  it('correctly skips boolean flags before --', () => {
+    const argv = [
+      ...BASE,
+      'env',
+      'run',
+      '--password-stdin',
+      '--',
+      'node',
+      's.js',
+    ];
+    expect(injectVaultEnvArg(argv, 'dev')).toEqual([
+      'node',
+      'cli',
+      'env',
+      'run',
+      '--password-stdin',
+      'dev',
+      '--',
+      'node',
+      's.js',
+    ]);
+  });
+
+  it('correctly skips flags-with-value pairs before --', () => {
+    const argv = [
+      ...BASE,
+      'env',
+      'run',
+      '--inject',
+      'merge',
+      '-v',
+      '/v',
+      '--',
+      'cmd',
+    ];
+    expect(injectVaultEnvArg(argv, 'prod')).toEqual([
+      'node',
+      'cli',
+      'env',
+      'run',
+      '--inject',
+      'merge',
+      '-v',
+      '/v',
+      'prod',
+      '--',
+      'cmd',
+    ]);
   });
 });

--- a/src/__tests__/cli/envRunHelpers.test.js
+++ b/src/__tests__/cli/envRunHelpers.test.js
@@ -1,11 +1,16 @@
 // @vitest-environment node
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs-extra';
+import os from 'os';
+import path from 'path';
 
 import {
   CLEAN_ALLOWLIST,
+  DEFAULT_ALLOWLIST_FILE,
   buildChildEnv,
   toDotenv,
   parseAllowlist,
+  readAllowlistFile,
 } from '../../../bin/commands/envRunHelpers.js';
 
 describe('buildChildEnv', () => {
@@ -89,5 +94,61 @@ describe('parseAllowlist', () => {
   it('returns [] for undefined/empty', () => {
     expect(parseAllowlist(undefined)).toEqual([]);
     expect(parseAllowlist('')).toEqual([]);
+  });
+});
+
+describe('DEFAULT_ALLOWLIST_FILE', () => {
+  it('is .vault-allowlist', () => {
+    expect(DEFAULT_ALLOWLIST_FILE).toBe('.vault-allowlist');
+  });
+});
+
+describe('readAllowlistFile', () => {
+  let tmpDir;
+  let tmpFile;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'vault-test-'));
+    tmpFile = path.join(tmpDir, 'allowlist.txt');
+  });
+
+  afterEach(async () => {
+    await fs.remove(tmpDir);
+  });
+
+  it('parses one var per line', async () => {
+    await fs.writeFile(tmpFile, 'LANG\nTERM\nNODE_PATH\n');
+    expect(readAllowlistFile(tmpFile)).toEqual(['LANG', 'TERM', 'NODE_PATH']);
+  });
+
+  it('strips # comments and blank lines', async () => {
+    await fs.writeFile(
+      tmpFile,
+      '# this is a comment\nLANG\n\n# another\nTERM\n'
+    );
+    expect(readAllowlistFile(tmpFile)).toEqual(['LANG', 'TERM']);
+  });
+
+  it('strips inline comments', async () => {
+    await fs.writeFile(tmpFile, 'LANG # locale\nTERM\n');
+    expect(readAllowlistFile(tmpFile)).toEqual(['LANG', 'TERM']);
+  });
+
+  it('returns [] for a falsy path', () => {
+    expect(readAllowlistFile(null)).toEqual([]);
+    expect(readAllowlistFile('')).toEqual([]);
+    expect(readAllowlistFile(undefined)).toEqual([]);
+  });
+
+  it('returns [] when file is absent and mustExist is false', () => {
+    expect(readAllowlistFile('/nonexistent/path/.vault-allowlist')).toEqual([]);
+  });
+
+  it('throws when file is absent and mustExist is true', () => {
+    expect(() =>
+      readAllowlistFile('/nonexistent/path/.vault-allowlist', {
+        mustExist: true,
+      })
+    ).toThrow(/Cannot read allowlist file/);
   });
 });

--- a/src/__tests__/cli/envRunHelpers.test.js
+++ b/src/__tests__/cli/envRunHelpers.test.js
@@ -7,10 +7,13 @@ import path from 'path';
 import {
   CLEAN_ALLOWLIST,
   DEFAULT_ALLOWLIST_FILE,
+  VAULTRC_FILENAME,
   buildChildEnv,
   toDotenv,
   parseAllowlist,
   readAllowlistFile,
+  loadProjectConfig,
+  applyProjectConfig,
 } from '../../../bin/commands/envRunHelpers.js';
 
 describe('buildChildEnv', () => {
@@ -150,5 +153,93 @@ describe('readAllowlistFile', () => {
         mustExist: true,
       })
     ).toThrow(/Cannot read allowlist file/);
+  });
+});
+
+describe('VAULTRC_FILENAME', () => {
+  it('is .vaultrc', () => {
+    expect(VAULTRC_FILENAME).toBe('.vaultrc');
+  });
+});
+
+describe('loadProjectConfig', () => {
+  let tmpDir;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'vault-rc-'));
+  });
+
+  afterEach(async () => {
+    await fs.remove(tmpDir);
+  });
+
+  it('returns {} when no .vaultrc exists', () => {
+    expect(loadProjectConfig(tmpDir)).toEqual({});
+  });
+
+  it('parses a valid .vaultrc in the start dir', async () => {
+    await fs.writeJson(path.join(tmpDir, '.vaultrc'), {
+      inject: 'merge',
+      env: 'staging',
+    });
+    expect(loadProjectConfig(tmpDir)).toEqual({
+      inject: 'merge',
+      env: 'staging',
+    });
+  });
+
+  it('walks up to find .vaultrc in a parent dir', async () => {
+    await fs.writeJson(path.join(tmpDir, '.vaultrc'), { inject: 'merge' });
+    const child = path.join(tmpDir, 'sub', 'dir');
+    await fs.mkdirp(child);
+    expect(loadProjectConfig(child)).toEqual({ inject: 'merge' });
+  });
+
+  it('stops walking at a .git boundary', async () => {
+    // .vaultrc lives above the git root — should NOT be found.
+    await fs.writeJson(path.join(tmpDir, '.vaultrc'), { inject: 'merge' });
+    const gitRoot = path.join(tmpDir, 'project');
+    await fs.mkdirp(path.join(gitRoot, '.git'));
+    expect(loadProjectConfig(gitRoot)).toEqual({});
+  });
+
+  it('throws on invalid JSON', async () => {
+    await fs.writeFile(path.join(tmpDir, '.vaultrc'), '{ bad json }');
+    expect(() => loadProjectConfig(tmpDir)).toThrow(/Invalid JSON/);
+  });
+});
+
+describe('applyProjectConfig', () => {
+  function makeCmd(defaults = {}) {
+    // Minimal Commander-like stub with option value source tracking.
+    const sources = {};
+    const values = { inject: 'clean', ...defaults };
+    for (const k of Object.keys(values)) sources[k] = 'default';
+    return {
+      getOptionValueSource: (k) => sources[k] ?? 'default',
+      setOptionValueWithSource: (k, v, src) => {
+        values[k] = v;
+        sources[k] = src;
+      },
+      opts: () => values,
+    };
+  }
+
+  it('sets a default option from config', () => {
+    const cmd = makeCmd();
+    applyProjectConfig(cmd, { inject: 'merge' });
+    expect(cmd.opts().inject).toBe('merge');
+  });
+
+  it('does not override a CLI-set option', () => {
+    const cmd = makeCmd();
+    cmd.setOptionValueWithSource('inject', 'file', 'cli');
+    applyProjectConfig(cmd, { inject: 'merge' });
+    expect(cmd.opts().inject).toBe('file');
+  });
+
+  it('ignores unknown keys in config', () => {
+    const cmd = makeCmd();
+    expect(() => applyProjectConfig(cmd, { unknown: 'value' })).not.toThrow();
   });
 });

--- a/src/__tests__/cli/envShell.integration.test.js
+++ b/src/__tests__/cli/envShell.integration.test.js
@@ -47,27 +47,6 @@ afterAll(() => {
   }
 });
 
-// Run `vault env shell` with a non-interactive shell that executes one command
-// and exits. This lets us inspect the environment without actually going interactive.
-function shellRun(envName, shellCmd, extraArgs = [], extraEnv = {}) {
-  return spawnSync(
-    NODE,
-    [CLI, 'env', 'shell', envName, '-v', vaultPath, ...extraArgs],
-    {
-      encoding: 'utf8',
-      env: {
-        ...process.env,
-        VAULT_ENV_PASSWORD: PASSWORD,
-        // Point SHELL at a wrapper that runs shellCmd then exits immediately.
-        SHELL: `${process.execPath}`,
-        ...extraEnv,
-      },
-      // Pipe stdin so the shell exits immediately when stdin closes.
-      input: '',
-    }
-  );
-}
-
 describe('vault env shell (integration)', () => {
   it('injects vault vars into the shell environment', () => {
     // Use node as the "shell" so we can inspect process.env without interaction.
@@ -83,7 +62,7 @@ describe('vault env shell (integration)', () => {
         'process.stdout.write(JSON.stringify(process.env)); process.exit(0);',
     });
     expect(r.status).toBe(0);
-    const env = JSON.parse(r.stdout.replace(/^[^\{]*/, '')); // strip banner
+    const env = JSON.parse(r.stdout.replace(/^[^{]*/, '')); // strip banner
     expect(env.API_URL).toBe('https://api.example.com');
     expect(env.TOKEN).toBe('sekret');
   });
@@ -96,7 +75,7 @@ describe('vault env shell (integration)', () => {
         'process.stdout.write(JSON.stringify(process.env)); process.exit(0);',
     });
     expect(r.status).toBe(0);
-    const env = JSON.parse(r.stdout.replace(/^[^\{]*/, ''));
+    const env = JSON.parse(r.stdout.replace(/^[^{]*/, ''));
     expect(env.VAULT_SHELL).toBe('1');
     expect(env.VAULT_SHELL_ENV).toBe('dev');
   });
@@ -118,7 +97,7 @@ describe('vault env shell (integration)', () => {
       }
     );
     expect(r.status).toBe(0);
-    const env = JSON.parse(r.stdout.replace(/^[^\{]*/, ''));
+    const env = JSON.parse(r.stdout.replace(/^[^{]*/, ''));
     expect(env.SECRET_SHOULD_NOT_LEAK).toBeUndefined();
     expect(env.API_URL).toBe('https://api.example.com');
   });
@@ -140,7 +119,7 @@ describe('vault env shell (integration)', () => {
       }
     );
     expect(r.status).toBe(0);
-    const env = JSON.parse(r.stdout.replace(/^[^\{]*/, ''));
+    const env = JSON.parse(r.stdout.replace(/^[^{]*/, ''));
     expect(env.MY_CUSTOM_VAR).toBe('hello');
     expect(env.API_URL).toBe('https://api.example.com');
   });

--- a/src/__tests__/cli/envShell.integration.test.js
+++ b/src/__tests__/cli/envShell.integration.test.js
@@ -1,0 +1,172 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CLI = path.resolve(__dirname, '../../../bin/cli.js');
+const NODE = process.execPath;
+const PASSWORD = 'TestVault123!@#';
+
+let vaultPath;
+
+function cli(args, extraEnv = {}) {
+  return spawnSync(NODE, [CLI, 'env', ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, VAULT_ENV_PASSWORD: PASSWORD, ...extraEnv },
+  });
+}
+
+beforeAll(() => {
+  vaultPath = path.join(
+    fs.mkdtempSync(path.join(os.tmpdir(), 'sv-shell-')),
+    'test.env.vault'
+  );
+  cli(['init', '-v', vaultPath]);
+  cli([
+    'set',
+    'API_URL',
+    'https://api.example.com',
+    '-e',
+    'dev',
+    '-v',
+    vaultPath,
+    '--public',
+  ]);
+  cli(['set', 'TOKEN', 'sekret', '-e', 'dev', '-v', vaultPath]);
+});
+
+afterAll(() => {
+  try {
+    fs.rmSync(path.dirname(vaultPath), { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+// Run `vault env shell` with a non-interactive shell that executes one command
+// and exits. This lets us inspect the environment without actually going interactive.
+function shellRun(envName, shellCmd, extraArgs = [], extraEnv = {}) {
+  return spawnSync(
+    NODE,
+    [CLI, 'env', 'shell', envName, '-v', vaultPath, ...extraArgs],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        VAULT_ENV_PASSWORD: PASSWORD,
+        // Point SHELL at a wrapper that runs shellCmd then exits immediately.
+        SHELL: `${process.execPath}`,
+        ...extraEnv,
+      },
+      // Pipe stdin so the shell exits immediately when stdin closes.
+      input: '',
+    }
+  );
+}
+
+describe('vault env shell (integration)', () => {
+  it('injects vault vars into the shell environment', () => {
+    // Use node as the "shell" so we can inspect process.env without interaction.
+    const r = spawnSync(NODE, [CLI, 'env', 'shell', 'dev', '-v', vaultPath], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        VAULT_ENV_PASSWORD: PASSWORD,
+        SHELL: NODE,
+      },
+      // Pass a node script via stdin — node reads from stdin when no file arg is given.
+      input:
+        'process.stdout.write(JSON.stringify(process.env)); process.exit(0);',
+    });
+    expect(r.status).toBe(0);
+    const env = JSON.parse(r.stdout.replace(/^[^\{]*/, '')); // strip banner
+    expect(env.API_URL).toBe('https://api.example.com');
+    expect(env.TOKEN).toBe('sekret');
+  });
+
+  it('sets VAULT_SHELL=1 and VAULT_SHELL_ENV in the shell environment', () => {
+    const r = spawnSync(NODE, [CLI, 'env', 'shell', 'dev', '-v', vaultPath], {
+      encoding: 'utf8',
+      env: { ...process.env, VAULT_ENV_PASSWORD: PASSWORD, SHELL: NODE },
+      input:
+        'process.stdout.write(JSON.stringify(process.env)); process.exit(0);',
+    });
+    expect(r.status).toBe(0);
+    const env = JSON.parse(r.stdout.replace(/^[^\{]*/, ''));
+    expect(env.VAULT_SHELL).toBe('1');
+    expect(env.VAULT_SHELL_ENV).toBe('dev');
+  });
+
+  it('clean mode does not leak parent env vars beyond the allowlist', () => {
+    const r = spawnSync(
+      NODE,
+      [CLI, 'env', 'shell', 'dev', '-v', vaultPath, '--inject', 'clean'],
+      {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          VAULT_ENV_PASSWORD: PASSWORD,
+          SHELL: NODE,
+          SECRET_SHOULD_NOT_LEAK: 'leaked',
+        },
+        input:
+          'process.stdout.write(JSON.stringify(process.env)); process.exit(0);',
+      }
+    );
+    expect(r.status).toBe(0);
+    const env = JSON.parse(r.stdout.replace(/^[^\{]*/, ''));
+    expect(env.SECRET_SHOULD_NOT_LEAK).toBeUndefined();
+    expect(env.API_URL).toBe('https://api.example.com');
+  });
+
+  it('merge mode inherits parent env vars', () => {
+    const r = spawnSync(
+      NODE,
+      [CLI, 'env', 'shell', 'dev', '-v', vaultPath, '--inject', 'merge'],
+      {
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          VAULT_ENV_PASSWORD: PASSWORD,
+          SHELL: NODE,
+          MY_CUSTOM_VAR: 'hello',
+        },
+        input:
+          'process.stdout.write(JSON.stringify(process.env)); process.exit(0);',
+      }
+    );
+    expect(r.status).toBe(0);
+    const env = JSON.parse(r.stdout.replace(/^[^\{]*/, ''));
+    expect(env.MY_CUSTOM_VAR).toBe('hello');
+    expect(env.API_URL).toBe('https://api.example.com');
+  });
+
+  it('rejects --inject file mode', () => {
+    const r = spawnSync(
+      NODE,
+      [CLI, 'env', 'shell', 'dev', '-v', vaultPath, '--inject', 'file'],
+      {
+        encoding: 'utf8',
+        env: { ...process.env, VAULT_ENV_PASSWORD: PASSWORD, SHELL: NODE },
+        input: '',
+      }
+    );
+    expect(r.status).toBe(1);
+    expect(r.stdout + r.stderr).toMatch(/clean\|merge/);
+  });
+
+  it('exits 1 when no envName and no VAULT_ENV', () => {
+    const env = { ...process.env, VAULT_ENV_PASSWORD: PASSWORD };
+    delete env.VAULT_ENV;
+    const r = spawnSync(NODE, [CLI, 'env', 'shell', '-v', vaultPath], {
+      encoding: 'utf8',
+      env,
+    });
+    expect(r.status).toBe(1);
+    expect(r.stdout + r.stderr).toMatch(/No environment specified/i);
+  });
+});


### PR DESCRIPTION
## Context

  `vault env run` and friends required passing the environment name, vault name, and injection mode explicitly on every invocation, and the clean-mode allowlist had to be specified inline. For repeated use in a project (CI, local dev, scripts) this was verbose and  error-prone. This PR is a batch of usability improvements that let a project declare its defaults once and run commands with minimal flags.

##  This Diff

Six self-contained additions to the vault env command surface:

  - `--allowlist-file` + auto-load .vault-allowlist — pass-through vars for --inject clean can be kept in a file (one per line, # comments);
  auto-loaded from CWD if present.
  - `.vaultrc` project config — walks up to the git root looking for .vaultrc, applying defaults for inject, env, name, vault,
  allowlistFile.
  - `VAULT_ENV` / `VAULT_NAME` / `VAULT_INJECT` env vars — environment-level fallbacks for the env name, vault name, and injection mode.
  - `--dry-run` on `vault env run` — prints the resolved environment without spawning the command.
  - `vault env shell` — new subcommand that drops into an interactive shell with the environment injected.
  - Docs — README.cli.md and docs/environments/SPEC.md updated to describe all of the above.

