### PR TITLE
Export mode support

### DIFF
--- a/README.cli.md
+++ b/README.cli.md
@@ -63,9 +63,59 @@ vault env diff dev prod          # compare two environments
 vault env history dev            # view version history
 vault env rollback 3 -e dev      # restore a previous version of "dev"
 vault env run dev -- npm start   # run a command with the env injected
+vault env run dev --export .env -- npm start   # also write a temp .env (wiped on exit)
 vault env run dev --dry-run      # preview what would be injected (no spawn)
 vault env shell dev              # open an interactive shell with the env loaded
 ```
+
+#### Running commands with secrets injected (`vault env run`)
+
+`vault env run` decrypts the environment, injects it into a child process, and
+cleans up afterwards — secrets never touch disk unless you ask. It has **two
+independent controls**:
+
+- **`--inject clean|merge`** — _how the child's process environment is built._
+  `clean` (default) passes only your vault vars plus a small allowlist
+  (`PATH`, `HOME`, `SHELL`, `USER`, `TMPDIR`); `merge` keeps your whole shell
+  env and layers vault vars on top.
+- **`--export <path>`** — _also write a temporary `.env` to disk_ for tools
+  that insist on reading one. It composes with either inject mode, so you can
+  have a clean process env **and** a file.
+
+| I want to…                                                | Command                                                         |
+| --------------------------------------------------------- | --------------------------------------------------------------- |
+| Run with only my vault vars (+ PATH/HOME/…), nothing else | `vault env run dev -- npm start`                                |
+| Keep my whole shell env and add vault vars on top         | `vault env run dev --inject merge -- npm start`                 |
+| Give a build tool a real `.env` (auto-wiped after)        | `vault env run dev --export .env -- npx react-native run-ios`   |
+| Add my own one-off variable                               | `vault env run dev --set FEATURE_FLAG=on -- npm test`           |
+| Load extra vars from a file                               | `vault env run dev --env-file .env.local -- npm test`           |
+| Let specific shell vars through in clean mode             | `vault env run dev --allowlist NODE_PATH,LANG -- npm run build` |
+| Preview what would be injected (no spawn)                 | `vault env run dev --dry-run`                                   |
+| Drop into an interactive shell with the env loaded        | `vault env shell dev`                                           |
+
+**`--export` details.** The file is created `0600`, the child receives
+`ENV_FILE_PATH=<path>` so tools can locate it, and it is securely deleted when
+the command exits — on success **or** failure. To avoid destroying a file you
+care about, `--export` refuses to overwrite an existing path unless you pass
+`--force`.
+
+**Your own variables vs. shell passthrough.** `--set KEY=VALUE` (repeatable)
+and `--env-file <path>` add _explicit_ variables: they are injected **and**
+written into the `--export` file, layered under your vault vars (the vault wins
+on a conflict, and `--set` beats `--env-file`). By contrast, `--inject merge`
+and `--allowlist` only let your _existing_ shell variables through to the
+process — they never get written to the exported file. So the on-disk `.env`
+always contains exactly "vault vars + your explicit additions".
+
+> **Heads-up on disk wiping.** The 3-pass overwrite is best-effort: on SSDs and
+> copy-on-write filesystems (APFS, btrfs) the original blocks may not be erased
+> in place, and a hard kill (`kill -9`) or power loss before the command exits
+> can leave the file behind. Treat `--export` as "auto-cleanup on normal exit",
+> not a guarantee against forensic recovery.
+
+> **Deprecation.** The older `--inject file --out-file <path>` is now an alias
+> for `--export <path>` and prints a warning; it is removed in v2.0. Replace
+> `--inject file --out-file X` with `--export X`.
 
 #### Zero-friction project setup
 

--- a/bin/commands/env.js
+++ b/bin/commands/env.js
@@ -1276,14 +1276,16 @@ export function registerEnvCommand(program) {
     .option('--password-file <path>', 'Read vault password from a file')
     .option('--password-stdin', 'Read vault password from stdin')
     .addOption(
-      new Option('--inject <mode>', 'Injection mode: clean | merge | file')
+      new Option(
+        '--inject <mode>',
+        'Population mode: clean | merge (file is a deprecated alias of --export)'
+      )
         .default('clean')
         .env('VAULT_INJECT')
     )
     .option(
       '--out-file <path>',
-      'Temp .env path to write (required for --inject file). Named --out-file ' +
-        'because Node/Bun reserve --env-file as a built-in flag.'
+      '[deprecated, removed in v2.0] alias of --export <path>.'
     )
     .option(
       '--export <path>',
@@ -1352,16 +1354,41 @@ export function registerEnvCommand(program) {
         process.exit(1);
       }
 
-      const mode = options.inject;
-      if (!INJECT_MODES.includes(mode)) {
+      // `--inject file` and `--out-file` are deprecated aliases for the
+      // orthogonal `--export` flag (to be removed in v2.0). `file` is no longer
+      // a population mode — it maps to clean and writes the file via --export.
+      const requestedInject = options.inject;
+      if (!INJECT_MODES.includes(requestedInject)) {
         console.error(
-          chalk.red(`Invalid --inject mode "${mode}" (clean|merge|file)`)
+          chalk.red(`Invalid --inject mode "${requestedInject}" (clean|merge)`)
         );
         process.exit(1);
       }
-      if (mode === 'file' && !options.outFile) {
+      const legacyFileMode = requestedInject === 'file';
+      const mode = legacyFileMode ? 'clean' : requestedInject;
+
+      if (legacyFileMode) {
         console.error(
-          chalk.red('--out-file <path> is required for --inject file')
+          chalk.yellow(
+            'warning: `--inject file` is deprecated and will be removed in ' +
+              'v2.0. Use `--export <path>` (clean is the default population mode).'
+          )
+        );
+      }
+      if (options.outFile) {
+        console.error(
+          chalk.yellow(
+            'warning: `--out-file` is deprecated and will be removed in v2.0. ' +
+              'Use `--export <path>`.'
+          )
+        );
+      }
+
+      // Single file target: --export (preferred) or the legacy --out-file.
+      const exportTarget = options.export ?? options.outFile;
+      if (legacyFileMode && !exportTarget) {
+        console.error(
+          chalk.red('--export <path> is required for --inject file')
         );
         process.exit(1);
       }
@@ -1419,15 +1446,10 @@ export function registerEnvCommand(program) {
           allowlist: [...parseAllowlist(options.allowlist), ...fileAllowlist],
         });
 
-        // File delivery is orthogonal to the population mode: --export writes
-        // a temp .env regardless of clean|merge. The legacy `--inject file`
-        // path (with --out-file) is still honored here; it is routed through
-        // the same single write path and deprecated in a later task.
-        const exportPath = options.export
-          ? path.resolve(options.export)
-          : mode === 'file'
-            ? path.resolve(options.outFile)
-            : null;
+        // File delivery is orthogonal to the population mode: a temp .env is
+        // written whenever a target was given via --export or the legacy
+        // --out-file / --inject file (resolved together as exportTarget).
+        const exportPath = exportTarget ? path.resolve(exportTarget) : null;
 
         // Let the child locate the written file (fixes the long-standing
         // missing-pointer bug where file mode never set this).

--- a/bin/commands/env.js
+++ b/bin/commands/env.js
@@ -15,6 +15,7 @@ import {
   buildChildEnv,
   toDotenv,
   parseAllowlist,
+  parseSetPairs,
   readAllowlistFile,
   loadProjectConfig,
   applyProjectConfig,
@@ -1296,6 +1297,18 @@ export function registerEnvCommand(program) {
         '(by default an existing file is left untouched and the run aborts).'
     )
     .option(
+      '--set <pair>',
+      'Add an explicit KEY=VALUE to the run (repeatable). Injected into the ' +
+        'child and included in --export output; layered under vault vars.',
+      (val, prev) => prev.concat(val),
+      []
+    )
+    .option(
+      '--env-file <path>',
+      'Load extra KEY=VALUE pairs from a .env file. Same placement as --set ' +
+        '(injected + exported, under vault vars; --set overrides --env-file).'
+    )
+    .option(
       '--allowlist <vars>',
       'Extra system vars to pass through in clean mode (comma-separated)'
     )
@@ -1369,6 +1382,28 @@ export function registerEnvCommand(program) {
 
         const vars = exportResult.data;
 
+        // Explicit user-supplied additions: --env-file first, then --set
+        // overrides it. These are injected into the child AND written to the
+        // --export file, but layered UNDER the vault vars (vault wins). This is
+        // distinct from --allowlist / merge, which only let parent-env values
+        // through to the process env and never enter the exported file.
+        let userVars = {};
+        if (options.envFile) {
+          const userEnvFilePath = path.resolve(options.envFile);
+          let content;
+          try {
+            content = fs.readFileSync(userEnvFilePath, 'utf-8');
+          } catch (err) {
+            throw new Error(
+              `Cannot read --env-file "${userEnvFilePath}": ${err.message}`
+            );
+          }
+          userVars = EnvironmentVault.parseEnvFile(content);
+        }
+        userVars = { ...userVars, ...parseSetPairs(options.set) };
+
+        const injectedVars = { ...userVars, ...vars };
+
         // Resolve allowlist file: explicit flag (must exist) or CWD default (optional).
         const allowlistFilePath = options.allowlistFile
           ? path.resolve(options.allowlistFile)
@@ -1379,7 +1414,7 @@ export function registerEnvCommand(program) {
 
         const childEnv = buildChildEnv({
           mode,
-          vars,
+          vars: injectedVars,
           parentEnv: process.env,
           allowlist: [...parseAllowlist(options.allowlist), ...fileAllowlist],
         });
@@ -1452,7 +1487,7 @@ export function registerEnvCommand(program) {
             );
             process.exit(1);
           }
-          fs.writeFileSync(exportPath, toDotenv(vars), { mode: 0o600 });
+          fs.writeFileSync(exportPath, toDotenv(injectedVars), { mode: 0o600 });
         }
 
         const cleanup = () => {

--- a/bin/commands/env.js
+++ b/bin/commands/env.js
@@ -1291,6 +1291,11 @@ export function registerEnvCommand(program) {
         'Composes with --inject clean|merge.'
     )
     .option(
+      '--force',
+      'Overwrite the --export / --out-file target if it already exists ' +
+        '(by default an existing file is left untouched and the run aborts).'
+    )
+    .option(
       '--allowlist <vars>',
       'Extra system vars to pass through in clean mode (comma-separated)'
     )
@@ -1434,6 +1439,19 @@ export function registerEnvCommand(program) {
         }
 
         if (exportPath) {
+          // Guard against clobbering a real file: since we securely delete the
+          // target on exit, silently overwriting an existing file would destroy
+          // it. Require --force to opt in.
+          if (fs.existsSync(exportPath) && !options.force) {
+            console.error(
+              chalk.red(
+                `Refusing to overwrite existing file ${exportPath} ` +
+                  `(it would be securely deleted when the command exits). ` +
+                  `Pass --force to override.`
+              )
+            );
+            process.exit(1);
+          }
           fs.writeFileSync(exportPath, toDotenv(vars), { mode: 0o600 });
         }
 

--- a/bin/commands/env.js
+++ b/bin/commands/env.js
@@ -1285,6 +1285,12 @@ export function registerEnvCommand(program) {
         'because Node/Bun reserve --env-file as a built-in flag.'
     )
     .option(
+      '--export <path>',
+      'Also write the resolved env to a temp .env at <path> (0600), set ' +
+        'ENV_FILE_PATH for the child, and securely delete it on exit. ' +
+        'Composes with --inject clean|merge.'
+    )
+    .option(
       '--allowlist <vars>',
       'Extra system vars to pass through in clean mode (comma-separated)'
     )
@@ -1373,6 +1379,20 @@ export function registerEnvCommand(program) {
           allowlist: [...parseAllowlist(options.allowlist), ...fileAllowlist],
         });
 
+        // File delivery is orthogonal to the population mode: --export writes
+        // a temp .env regardless of clean|merge. The legacy `--inject file`
+        // path (with --out-file) is still honored here; it is routed through
+        // the same single write path and deprecated in a later task.
+        const exportPath = options.export
+          ? path.resolve(options.export)
+          : mode === 'file'
+            ? path.resolve(options.outFile)
+            : null;
+
+        // Let the child locate the written file (fixes the long-standing
+        // missing-pointer bug where file mode never set this).
+        if (exportPath) childEnv.ENV_FILE_PATH = exportPath;
+
         if (options.dryRun) {
           // Build a sensitivity map from showEnv; inherited vars default to sensitive.
           const showResult = await EnvironmentVaultService.showEnv(
@@ -1387,10 +1407,9 @@ export function registerEnvCommand(program) {
             }
           }
 
-          const modeLabel =
-            mode === 'file'
-              ? `${mode} (vars written to ${options.outFile ?? '<out-file>'})`
-              : mode;
+          const modeLabel = exportPath
+            ? `${mode} (env also written to ${exportPath})`
+            : mode;
           log(
             chalk.bold(
               `\nDry run — env: ${chalk.cyan(envName)}  mode: ${chalk.cyan(modeLabel)}\n`
@@ -1414,14 +1433,12 @@ export function registerEnvCommand(program) {
           return;
         }
 
-        let envFilePath = null;
-        if (mode === 'file') {
-          envFilePath = path.resolve(options.outFile);
-          fs.writeFileSync(envFilePath, toDotenv(vars), { mode: 0o600 });
+        if (exportPath) {
+          fs.writeFileSync(exportPath, toDotenv(vars), { mode: 0o600 });
         }
 
         const cleanup = () => {
-          if (envFilePath) secureDelete(envFilePath);
+          if (exportPath) secureDelete(exportPath);
         };
 
         const child = spawn(command[0], command.slice(1), {

--- a/bin/commands/envRunHelpers.js
+++ b/bin/commands/envRunHelpers.js
@@ -43,11 +43,32 @@ export function buildChildEnv({
   return { ...base, ...vars };
 }
 
-/** Serialize a key/value map to dotenv format. */
+/**
+ * Quote/escape a single dotenv value so it survives the line-based parser
+ * (EnvironmentVault.parseEnvFile) unchanged. A value is double-quoted with
+ * \\, \", \n, \r escaped when it would otherwise be corrupted unquoted —
+ * i.e. it contains a newline or quote char, a `#`, or has leading/trailing
+ * whitespace (which the parser would trim away). Plain values are emitted raw.
+ */
+export function quoteDotenvValue(value) {
+  const str = value == null ? '' : String(value);
+  const needsQuoting =
+    str !== '' &&
+    (str !== str.trim() || /[\n\r"']/.test(str) || str.includes('#'));
+  if (!needsQuoting) return str;
+  const escaped = str
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r');
+  return `"${escaped}"`;
+}
+
+/** Serialize a key/value map to dotenv format (values quoted/escaped as needed). */
 export function toDotenv(vars) {
   return (
     Object.entries(vars)
-      .map(([key, value]) => `${key}=${value}`)
+      .map(([key, value]) => `${key}=${quoteDotenvValue(value)}`)
       .join('\n') + '\n'
   );
 }

--- a/bin/commands/envRunHelpers.js
+++ b/bin/commands/envRunHelpers.js
@@ -14,10 +14,15 @@ export const INJECT_MODES = ['clean', 'merge', 'file'];
 /**
  * Build the environment object for the spawned child process.
  *
- * - clean  (default): only the vault vars + an allowlist of system vars
- * - merge:            vault vars layered on top of the inherited environment
- * - file:             no vault vars injected (they go to a temp file instead);
- *                     the child inherits the parent environment
+ * Population is a single axis with two modes; writing a `.env` file to disk is
+ * an orthogonal concern handled by the caller (see `--export`), not a mode here.
+ *
+ * - clean (default): only the vault vars + an allowlist of system vars
+ * - merge:           vault vars layered on top of the inherited environment
+ *
+ * Vault vars are ALWAYS injected. Any unrecognized mode (e.g. the legacy
+ * `file`, kept working as a deprecated alias at the run layer) falls back to
+ * clean — it never silently passes the full parent env through unfiltered.
  */
 export function buildChildEnv({
   mode = 'clean',
@@ -28,11 +33,8 @@ export function buildChildEnv({
   if (mode === 'merge') {
     return { ...parentEnv, ...vars };
   }
-  if (mode === 'file') {
-    return { ...parentEnv };
-  }
 
-  // clean
+  // clean (also the safe fallback for any non-merge mode)
   const allowed = new Set([...CLEAN_ALLOWLIST, ...allowlist]);
   const base = {};
   for (const key of allowed) {

--- a/bin/commands/envRunHelpers.js
+++ b/bin/commands/envRunHelpers.js
@@ -73,6 +73,23 @@ export function toDotenv(vars) {
   );
 }
 
+/**
+ * Parse repeatable `--set KEY=VALUE` pairs into an object. The value may itself
+ * contain `=` (only the first `=` is the separator). Throws on a pair with no
+ * `=` or an empty key. Later pairs override earlier ones for the same key.
+ */
+export function parseSetPairs(pairs = []) {
+  const out = {};
+  for (const pair of pairs) {
+    const eq = pair.indexOf('=');
+    if (eq <= 0) {
+      throw new Error(`Invalid --set "${pair}" (expected KEY=VALUE)`);
+    }
+    out[pair.slice(0, eq)] = pair.slice(eq + 1);
+  }
+  return out;
+}
+
 /** Parse a comma-separated allowlist string into a clean array. */
 export function parseAllowlist(value) {
   if (!value) return [];

--- a/bin/commands/envRunHelpers.js
+++ b/bin/commands/envRunHelpers.js
@@ -43,35 +43,10 @@ export function buildChildEnv({
   return { ...base, ...vars };
 }
 
-/**
- * Quote/escape a single dotenv value so it survives the line-based parser
- * (EnvironmentVault.parseEnvFile) unchanged. A value is double-quoted with
- * \\, \", \n, \r escaped when it would otherwise be corrupted unquoted —
- * i.e. it contains a newline or quote char, a `#`, or has leading/trailing
- * whitespace (which the parser would trim away). Plain values are emitted raw.
- */
-export function quoteDotenvValue(value) {
-  const str = value == null ? '' : String(value);
-  const needsQuoting =
-    str !== '' &&
-    (str !== str.trim() || /[\n\r"']/.test(str) || str.includes('#'));
-  if (!needsQuoting) return str;
-  const escaped = str
-    .replace(/\\/g, '\\\\')
-    .replace(/"/g, '\\"')
-    .replace(/\n/g, '\\n')
-    .replace(/\r/g, '\\r');
-  return `"${escaped}"`;
-}
-
-/** Serialize a key/value map to dotenv format (values quoted/escaped as needed). */
-export function toDotenv(vars) {
-  return (
-    Object.entries(vars)
-      .map(([key, value]) => `${key}=${quoteDotenvValue(value)}`)
-      .join('\n') + '\n'
-  );
-}
+// Dotenv serialization is shared with `vault env export` (the electron
+// service), so it lives in src/utils/dotenv.js. Re-exported here for the
+// CLI runner and existing importers.
+export { quoteDotenvValue, toDotenv } from '../../src/utils/dotenv.js';
 
 /**
  * Parse repeatable `--set KEY=VALUE` pairs into an object. The value may itself

--- a/docs/environments/SPEC.md
+++ b/docs/environments/SPEC.md
@@ -3,7 +3,7 @@
 > Feature: Securely manage, version, and inject environment variables from an encrypted
 > `.env.vault` file into development tools, build processes, and CI/CD pipelines.
 >
-> Status: **v1.5 delivered** · Revision 6
+> Status: **v1.5 delivered** · Revision 8
 
 ---
 
@@ -62,7 +62,7 @@ that require one.
 | Encryption               | Reuse `CryptographyService` | AES-256-GCM, PBKDF2 SHA-512, 100k iterations                  |
 | Primary interface        | CLI (`vault env *`)         | Works everywhere; no UI dependency                            |
 | Process injection        | `vault env run` wrapper     | Child process spawn; secrets never written to disk by default |
-| Delivery for build tools | `--env-file` flag           | Temp `.env` file created for child lifetime, then wiped       |
+| Delivery for build tools | `--export <path>` flag      | Temp `.env` created for child lifetime, then securely wiped   |
 | Daemon                   | CLI-only (v1)               | Agent/mount mode deferred to v2                               |
 
 ---
@@ -722,22 +722,46 @@ To undo a rollback, rollback again to the version before it.
 
 USAGE
 vault env run [env] [--vault <path>]
-[--inject clean|merge|file]
-[--out-file <path>]
+[--inject clean|merge]
+[--export <path>] [--force]
+[--set <KEY=VALUE>]... [--env-file <path>]
 [--allowlist <comma-separated-vars>]
 [--allowlist-file <path>]
 [--dry-run]
 [--] <command>...
 
-FLAGS
---inject <mode>
-clean (default) Only vault vars + allowlisted system vars (PATH, HOME, SHELL, USER, TMPDIR)
-merge Vault vars merged into inherited process.env
-file Write --out-file, spawn, then securely delete the file
+`run` has two independent axes (see §11):
+(1) PROCESS-ENV POPULATION — how the child's environment is built (--inject)
+(2) FILE DELIVERY — whether a .env is also written to disk (--export)
+These compose freely: e.g. clean-isolated env AND an on-disk file at once.
 
---out-file <path>
-Path to write a temporary .env file. Required when --inject=file.
-The file is created 0600 before spawn and securely deleted after child exits.
+FLAGS
+--inject <mode> (population axis)
+clean (default) Only vault vars + allowlisted system vars (PATH, HOME, SHELL, USER, TMPDIR)
+merge Vault vars merged into the inherited process.env
+(In every mode the vault vars are injected into the process env.)
+
+--export <path> (file-delivery axis)
+Also write the resolved env to a temp .env at <path> (created 0600),
+set ENV_FILE_PATH in the child so tools can locate it, then securely
+delete the file after the child exits (success OR failure). Composes
+with --inject clean|merge.
+
+--force
+Overwrite the --export target if it already exists. By default an
+existing file is left untouched and the run aborts — because the target
+is securely deleted on exit, silently clobbering a real .env would
+destroy it.
+
+--set <KEY=VALUE> (repeatable)
+Add an explicit variable to the run. Injected into the child AND written
+to the --export file, layered UNDER the vault vars (vault wins on
+conflict). Distinct from --allowlist/merge, which only pass parent-env
+values through and never enter the exported file.
+
+--env-file <path>
+Load extra KEY=VALUE pairs from a .env file (parsed exactly like
+`vault env import`). Same placement as --set; --set overrides --env-file.
 
 --allowlist <vars>
 Additional system vars to allow through in clean mode (comma-separated).
@@ -749,6 +773,12 @@ Defaults to .vault-allowlist in CWD if present; explicit path must exist.
 --dry-run
 Print the resolved environment without spawning the command.
 Vault vars are marked with '+'; sensitive values are masked as \*\*\*\*.
+
+DEPRECATED (removed in v2.0)
+--inject file Was a third "mode" that conflated population with file
+delivery. Now an alias for `--inject clean --export <path>`;
+emits a stderr deprecation warning. Use --export instead.
+--out-file <path> Alias of --export <path>; emits a deprecation warning.
 
 ENV VARS
 VAULT_ENV Default environment name (overridden by positional arg or .vaultrc)
@@ -762,25 +792,33 @@ A .vaultrc JSON file at the project root (walks up to git root) sets defaults
 for any of: inject, env, name, vault, allowlistFile.
 
 DESCRIPTION
-Decrypts the env vault, resolves templates, validates required vars,
-and spawns the command with environment variables injected according to
-the --inject mode. The child process inherits stdio.
+Decrypts the env vault, resolves templates, validates required vars, builds
+the child environment per --inject, optionally writes a temp .env per
+--export, and spawns the command (inheriting stdio).
 
-On exit, all temp files are securely deleted and decrypted data is zeroed.
+On exit, any --export file is securely deleted and decrypted data is zeroed.
 
 EXAMPLES
 
-# Inject env vars into npm start (clean mode)
+# Inject env vars into npm start (clean mode, no file on disk)
 
 vault env run development -- npm start
 
-# Merge mode for tools that need full parent env
+# Merge mode for tools that need the full parent env
 
 vault env run development --inject merge -- npx react-native run-ios
 
-# Temp .env file for react-native-config build
+# Clean-isolated env AND a temp .env for a file-based build tool
 
-vault env run staging --inject file --out-file .env -- npx react-native run-ios
+vault env run staging --export .env -- npx react-native run-ios
+
+# Add an explicit var (injected + written to the export file)
+
+vault env run staging --set FEATURE_FLAG=on --export .env -- npm run build
+
+# Load extra vars from a file; --set overrides them
+
+vault env run staging --env-file .env.local --set NODE_ENV=test -- npm test
 
 # Clean mode with additional system vars allowed
 
@@ -1095,23 +1133,25 @@ User CLI Child Process
 
 ```
 
-### 7.3 CLI Runner (file mode for build tools)
+### 7.3 CLI Runner (--export, for file-based build tools)
 
 ```
 
 User CLI Filesystem Child Process
 │ │ │ │
 ├─ vault env run ────→│ │ │
-│ staging --env-file │ │ │
+│ staging --export │ │ │
 │ .env -- react- │ │ │
 │ native run-ios │ │ │
 │ ├─ decrypt vault │ │
 │ ├─ resolve templates │ │
+│ ├─ abort if .env exists│ │
+│ │ (unless --force) │ │
 │ ├─ write .env ──────────→│ │
-│ │ (chmod 600) │ │
+│ │ (chmod 600, escaped) │ │
 │ │ │ │
-│ ├─ set REACT*NATIVE* │ │
-│ │ ENV_PATH=.env │ │
+│ ├─ build clean env + │ │
+│ │ ENV_FILE_PATH=.env │ │
 │ │ │ │
 │ ├─ spawn ───────────────→│──── .env ─────────→│
 │ │ │ │
@@ -1319,50 +1359,78 @@ With `--strict`, warnings are promoted to errors and the command fails.
 
 ---
 
-## 11. Injection Modes
+## 11. Injection Model
 
-### 11.1 Clean Mode (Default)
+`run` has **two independent axes**. Earlier revisions modeled file output as a
+third `--inject` value (`file`), which conflated them; that is now decoupled
+(see §16.9).
+
+| Axis                       | Flag                    | Question it answers                     |
+| -------------------------- | ----------------------- | --------------------------------------- |
+| (1) Process-env population | `--inject clean\|merge` | How is the child's `process.env` built? |
+| (2) File delivery          | `--export <path>`       | Is a `.env` also written to disk?       |
+
+In **all** cases the resolved vault vars (plus any `--set`/`--env-file`
+additions) are injected into the child's process env. The axes compose: e.g.
+`--inject clean --export .env` gives a clean-isolated env **and** an on-disk
+file.
+
+### 11.1 Population: Clean (default)
 
 ```
 cleanEnv = {
   ...allowlist,       // PATH, HOME, SHELL, USER, TMPDIR + custom --allowlist
-  ...vaultEnv         // resolved env vars from the vault
+  ...userVars,        // --env-file then --set (under vault)
+  ...vaultEnv         // resolved env vars from the vault (win on collision)
 }
 ```
 
 - System vars on the allowlist are inherited from the parent process.
 - All other parent env vars are stripped.
-- Vault vars override allowlist vars if there's a collision.
+- Vault vars override allowlist and user vars if there's a collision.
 
-### 11.2 Merge Mode
+### 11.2 Population: Merge
 
 ```
 mergedEnv = {
   ...process.env,     // all parent env vars
-  ...vaultEnv         // vault vars override parent
+  ...userVars,        // --env-file then --set
+  ...vaultEnv         // vault vars override parent and user vars
 }
 ```
 
 - Full inheritance of parent environment.
 - Vault vars take precedence.
 
-### 11.3 File Mode
+### 11.3 File Delivery (`--export <path>`)
 
 ```
-1. Resolve vault path
-2. Decrypt vault, resolve env
-3. Write .env file at --env-file path (chmod 600)
-4. Build child env:
-     cleanEnv (or mergedEnv if --inject merge)
-     + ENV_FILE_PATH=<path>   // set so child tools can locate it
-5. Spawn child
-6. On child exit:
-     a. Overwrite file with random data (3 passes)
-     b. Unlink file
-     c. Zero decrypted data in memory
+1. Build the child env per §11.1/§11.2 and set ENV_FILE_PATH=<path>.
+2. If <path> exists and --force was NOT given → abort (do not overwrite).
+3. Write the resolved vault + user vars to <path> as dotenv (chmod 600).
+   Values with newlines/quotes/# or edge whitespace are quoted+escaped so
+   they round-trip through `vault env import` (§16.10).
+4. Spawn the child (stdio inherited).
+5. On child exit (success OR failure):
+     a. Overwrite the file with random data (3 passes), then unlink.
+     b. Zero decrypted data in memory.
 ```
 
-The `ENV_FILE_PATH` env var allows tools that accept an env file path to find it.
+`ENV_FILE_PATH` lets tools that accept an env-file path locate the file. Only
+vault vars and explicit `--set`/`--env-file` additions are written — ambient
+allowlist/merge passthrough never lands in the file.
+
+> **Note (secure-delete caveat).** The 3-pass overwrite is best-effort: on
+> SSDs and copy-on-write filesystems (APFS, btrfs) wear-leveling means the
+> original blocks may not be overwritten in place. A `SIGKILL` of the parent
+> (or power loss) before the child exits can also leave the file on disk; the
+> startup orphan scan only covers temp dirs, not arbitrary `--export` paths.
+
+### 11.4 Deprecated: `--inject file` / `--out-file`
+
+`--inject file` (with `--out-file`) was the original file-delivery mechanism.
+It is now an alias for `--inject clean --export <out-file>`, emits a stderr
+deprecation warning, and is **removed in v2.0**. Use `--export` instead.
 
 ---
 
@@ -1388,7 +1456,7 @@ The `ENV_FILE_PATH` env var allows tools that accept an env file path to find it
 
 ### 12.3 Temp File Cleanup
 
-When `--inject file` or `--env-file` is used:
+When `--export <path>` (or the deprecated `--inject file` / `--out-file`) is used:
 
 1. File is created with `fs.open(path, 'w', 0o600)` — owner read/write only.
 2. On child exit (success or failure):
@@ -1496,7 +1564,7 @@ the vault, and `vault env get API_URL -e staging --clip` copies the value to cli
 
 **Dependencies**: v0.5
 
-**Exit criteria**: A React Native developer can run `vault env run staging --env-file .env -- npx react-native run-ios` with no plaintext `.env` on disk afterward. CI user can run `vault env validate prod --strict` in a pre-deploy hook.
+**Exit criteria**: A React Native developer can run `vault env run staging --export .env -- npx react-native run-ios` with no plaintext `.env` on disk afterward. CI user can run `vault env validate prod --strict` in a pre-deploy hook.
 
 ---
 
@@ -1912,6 +1980,47 @@ explaining the cross-module spy. Risk if left: a future fs-extra update that
 wraps `readFileSync` (e.g., for promisification) silently breaks the test
 or — worse — makes the test pass against fs-extra while production drifts.
 
+### 16.9 `--inject file` conflated population with file delivery
+
+**Where seen:** old §11.3 (File Mode), §6.3 `run` flags, implementation in
+`bin/commands/env.js` + `buildChildEnv` in `bin/commands/envRunHelpers.js`.
+
+**Divergence:** the old spec said file mode built `cleanEnv (or mergedEnv if
+--inject merge) + ENV_FILE_PATH`. The implementation did neither: `file` mode
+returned the **unfiltered parent env**, injected **no** vault vars, and never
+set `ENV_FILE_PATH`. The flag also can't express "merged env AND a file"
+because `--inject` is a single value, so the spec's own "(or mergedEnv if
+--inject merge)" was unrepresentable.
+
+**RESOLVED** — population (`--inject clean|merge`) and file delivery
+(`--export <path>`) are now separate axes (§11). Vault vars are always
+injected; `ENV_FILE_PATH` is always set when a file is written. `--inject
+file`/`--out-file` are soft-deprecated aliases of `--export` (stderr warning,
+removed in v2.0). Added `--set`/`--env-file` for explicit user vars and
+`--force` for the overwrite guard.
+
+### 16.10 Exported `.env` values were not escaped (round-trip / data loss)
+
+**Where seen:** old `toDotenv` (`bin/commands/envRunHelpers.js`) and the file
+write in `vault env run`.
+
+**Two issues:** (a) values were written raw `KEY=value`, so a value with a
+newline, quote, or leading/trailing whitespace produced a malformed file that
+`vault env import` (`EnvironmentVault.parseEnvFile`) could not read back
+identically; (b) the file was written with no existence check and securely
+deleted on exit, so pointing `--export`/`--out-file` at a real `.env`
+destroyed it.
+
+**RESOLVED** — `toDotenv` now double-quotes and escapes (`\\ \" \n \r`) values
+that need it, and `parseEnvFile` decodes those escapes for double-quoted
+values, making writer and reader a matched pair (verified by a round-trip
+test). The write now aborts on an existing target unless `--force` is given.
+
+> Follow-up: `vault env export --format dotenv` (stdout) still uses a separate
+> raw serializer in `EnvironmentVaultService.exportEnv`; unifying it with the
+> escaping helper is tracked as a future cleanup (needs a shared
+> bin/electron utility).
+
 ---
 
 ## 17. Appendix: Comparison to 1Password Environments
@@ -1974,12 +2083,13 @@ or — worse — makes the test pass against fs-extra while production drifts.
 
 ## Appendix C: Changelog
 
-| Date       | Revision | Author  | Changes                                                                                                                                                                                                                                                                                                                                       |
-| ---------- | -------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 2026-05-30 | 1        | wbenzid | Initial draft                                                                                                                                                                                                                                                                                                                                 |
-| 2026-05-26 | 2        | wbenzid | Add §16 Known Issues & Pending Reconciliations (8 items from v0.1.0-rc.5 e2e validation)                                                                                                                                                                                                                                                      |
-| 2026-06-06 | 3        | wbenzid | Codify var-level vs env-level command split (§6.1, §6.1.1); align all §6.3 usage/examples and §7 flows to the implementation; mark §16.1–16.3 RESOLVED (option b)                                                                                                                                                                             |
-| 2026-06-06 | 4        | wbenzid | Document password resolution (§6.2.1: precedence, mutual exclusion, exit codes); update §12.5; add `PASSWORD_*` codes to Appendix B; mark §16.5 RESOLVED (docs)                                                                                                                                                                               |
-| 2026-06-06 | 5        | wbenzid | Document walk-up + git-root vault discovery (§5.2/§5.3); mark §16.6 RESOLVED. Fix duplicate §6.1 heading (now §6.1.1/6.1.2/6.1.3) and stale cross-refs                                                                                                                                                                                        |
-| 2026-06-11 | 6        | wbenzid | Mark v1.5 Composition delivered (resolver: `extends` layering + `{{env:name/KEY}}`/`{{env:self/KEY}}` refs + full validation engine); add `.bak`/atomic-write + `.deleted.<ts>` (§5.4); reserve `self` env name (§4.5/§8); add milestone status legend + v0.5/v1.0/v2.x markers; note Q1/Q4 status in §15                                     |
-| 2026-06-15 | 7        | wbenzid | Mark v1.0 hardening complete in §13.3 (3-pass temp cleanup, orphan scan, distinct error codes 2–14 with symbolic emission); add `show` fields, `diff` old→new, `history` date col, spec limit enforcement, `--description`, `--quiet` to §13.4 delivered; close §16.5 (error codes); add numeric exit code column + status note to Appendix B |
+| Date       | Revision | Author  | Changes                                                                                                                                                                                                                                                                                                                                                                                |
+| ---------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-05-30 | 1        | wbenzid | Initial draft                                                                                                                                                                                                                                                                                                                                                                          |
+| 2026-05-26 | 2        | wbenzid | Add §16 Known Issues & Pending Reconciliations (8 items from v0.1.0-rc.5 e2e validation)                                                                                                                                                                                                                                                                                               |
+| 2026-06-06 | 3        | wbenzid | Codify var-level vs env-level command split (§6.1, §6.1.1); align all §6.3 usage/examples and §7 flows to the implementation; mark §16.1–16.3 RESOLVED (option b)                                                                                                                                                                                                                      |
+| 2026-06-06 | 4        | wbenzid | Document password resolution (§6.2.1: precedence, mutual exclusion, exit codes); update §12.5; add `PASSWORD_*` codes to Appendix B; mark §16.5 RESOLVED (docs)                                                                                                                                                                                                                        |
+| 2026-06-06 | 5        | wbenzid | Document walk-up + git-root vault discovery (§5.2/§5.3); mark §16.6 RESOLVED. Fix duplicate §6.1 heading (now §6.1.1/6.1.2/6.1.3) and stale cross-refs                                                                                                                                                                                                                                 |
+| 2026-06-11 | 6        | wbenzid | Mark v1.5 Composition delivered (resolver: `extends` layering + `{{env:name/KEY}}`/`{{env:self/KEY}}` refs + full validation engine); add `.bak`/atomic-write + `.deleted.<ts>` (§5.4); reserve `self` env name (§4.5/§8); add milestone status legend + v0.5/v1.0/v2.x markers; note Q1/Q4 status in §15                                                                              |
+| 2026-06-15 | 7        | wbenzid | Mark v1.0 hardening complete in §13.3 (3-pass temp cleanup, orphan scan, distinct error codes 2–14 with symbolic emission); add `show` fields, `diff` old→new, `history` date col, spec limit enforcement, `--description`, `--quiet` to §13.4 delivered; close §16.5 (error codes); add numeric exit code column + status note to Appendix B                                          |
+| 2026-06-30 | 8        | wbenzid | Decouple `run` into two axes — population (`--inject clean\|merge`) vs file delivery (`--export <path>`); rewrite §6.3 `run` flags and §11 (now "Injection Model"); add `--set`/`--env-file`/`--force`; soft-deprecate `--inject file`/`--out-file` (removed v2.0); add §16.9 (file-mode conflation RESOLVED) and §16.10 (value escaping + overwrite guard RESOLVED); update §7.3 flow |

--- a/docs/environments/SPEC.md
+++ b/docs/environments/SPEC.md
@@ -2016,10 +2016,10 @@ that need it, and `parseEnvFile` decodes those escapes for double-quoted
 values, making writer and reader a matched pair (verified by a round-trip
 test). The write now aborts on an existing target unless `--force` is given.
 
-> Follow-up: `vault env export --format dotenv` (stdout) still uses a separate
-> raw serializer in `EnvironmentVaultService.exportEnv`; unifying it with the
-> escaping helper is tracked as a future cleanup (needs a shared
-> bin/electron utility).
+> **Also resolved:** `vault env export --format dotenv` (stdout) now shares the
+> same serializer. The escaping helper lives in `src/utils/dotenv.js` and is
+> used by both the CLI runner (`--export`) and `EnvironmentVaultService.exportEnv`,
+> so exported and run-injected files quote/escape identically.
 
 ---
 

--- a/src/__tests__/cli/envRun.integration.test.js
+++ b/src/__tests__/cli/envRun.integration.test.js
@@ -256,6 +256,86 @@ describe('vault env run (integration)', () => {
     expect(fs.existsSync(envFile)).toBe(false);
   });
 
+  it('--set injects user vars into the child env, layered under vault vars', () => {
+    const r = cli([
+      'run',
+      'dev',
+      '--set',
+      'FEATURE_FLAG=on',
+      '--set',
+      'API_URL=should-lose-to-vault',
+      '-v',
+      vaultPath,
+      '--',
+      ...PRINT_ENV,
+    ]);
+    expect(r.status).toBe(0);
+    const env = JSON.parse(r.stdout);
+    expect(env.FEATURE_FLAG).toBe('on'); // user var injected
+    expect(env.API_URL).toBe('https://api.example.com'); // vault wins on conflict
+  });
+
+  it('--set values are written into the --export file alongside vault vars', () => {
+    const envFile = path.join(path.dirname(vaultPath), 'with-set.env');
+    const r = cli([
+      'run',
+      'dev',
+      '--set',
+      'FEATURE_FLAG=on',
+      '--export',
+      envFile,
+      '-v',
+      vaultPath,
+      '--',
+      NODE,
+      '-e',
+      `process.stdout.write(require('fs').readFileSync(process.env.ENV_FILE_PATH,'utf8'))`,
+    ]);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain('FEATURE_FLAG=on');
+    expect(r.stdout).toContain('API_URL=https://api.example.com');
+    expect(fs.existsSync(envFile)).toBe(false);
+  });
+
+  it('--env-file loads extra vars, and --set overrides --env-file', () => {
+    const extra = path.join(path.dirname(vaultPath), 'extra.env');
+    fs.writeFileSync(extra, 'FROM_FILE=filevalue\nOVERRIDE_ME=fromfile\n');
+    const r = cli([
+      'run',
+      'dev',
+      '--env-file',
+      extra,
+      '--set',
+      'OVERRIDE_ME=fromset',
+      '-v',
+      vaultPath,
+      '--',
+      ...PRINT_ENV,
+    ]);
+    fs.rmSync(extra);
+    expect(r.status).toBe(0);
+    const env = JSON.parse(r.stdout);
+    expect(env.FROM_FILE).toBe('filevalue'); // loaded from --env-file
+    expect(env.OVERRIDE_ME).toBe('fromset'); // --set beats --env-file
+  });
+
+  it('exits 1 on a malformed --set pair', () => {
+    const r = cli([
+      'run',
+      'dev',
+      '--set',
+      'NOEQUALS',
+      '-v',
+      vaultPath,
+      '--',
+      NODE,
+      '-e',
+      '0',
+    ]);
+    expect(r.status).toBe(1);
+    expect(r.stdout + r.stderr).toMatch(/expected KEY=VALUE/);
+  });
+
   it('exits 127 when the command is not found', () => {
     const r = cli(['run', 'dev', '-v', vaultPath, '--', 'no-such-cmd-xyz-123']);
     expect(r.status).toBe(127);

--- a/src/__tests__/cli/envRun.integration.test.js
+++ b/src/__tests__/cli/envRun.integration.test.js
@@ -336,6 +336,61 @@ describe('vault env run (integration)', () => {
     expect(r.stdout + r.stderr).toMatch(/expected KEY=VALUE/);
   });
 
+  it('--dry-run with --export reports the path but writes no file', () => {
+    const envFile = path.join(path.dirname(vaultPath), 'dry.env');
+    const r = cli([
+      'run',
+      'dev',
+      '--export',
+      envFile,
+      '--dry-run',
+      '-v',
+      vaultPath,
+    ]);
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/env also written to/);
+    expect(fs.existsSync(envFile)).toBe(false); // dry-run never writes
+  });
+
+  it('.vaultrc inject:"file" is honored as deprecated and routed to --export', () => {
+    const rcDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sv-rc-'));
+    fs.writeFileSync(
+      path.join(rcDir, '.vaultrc'),
+      JSON.stringify({ inject: 'file' })
+    );
+    const envFile = path.join(rcDir, 'rc.env');
+    try {
+      const r = spawnSync(
+        NODE,
+        [
+          CLI,
+          'env',
+          'run',
+          'dev',
+          '--export',
+          envFile,
+          '-v',
+          vaultPath,
+          '--',
+          ...PRINT_ENV,
+        ],
+        {
+          encoding: 'utf8',
+          cwd: rcDir,
+          env: { ...process.env, VAULT_ENV_PASSWORD: PASSWORD },
+        }
+      );
+      expect(r.status).toBe(0);
+      expect(r.stderr).toMatch(/--inject file` is deprecated/);
+      const env = JSON.parse(r.stdout);
+      expect(env.API_URL).toBe('https://api.example.com'); // vault var injected
+      expect(env.VAULT_ENV_PASSWORD).toBeUndefined(); // file -> clean isolation
+      expect(fs.existsSync(envFile)).toBe(false); // deleted after exit
+    } finally {
+      fs.rmSync(rcDir, { recursive: true, force: true });
+    }
+  });
+
   it('exits 127 when the command is not found', () => {
     const r = cli(['run', 'dev', '-v', vaultPath, '--', 'no-such-cmd-xyz-123']);
     expect(r.status).toBe(127);

--- a/src/__tests__/cli/envRun.integration.test.js
+++ b/src/__tests__/cli/envRun.integration.test.js
@@ -341,7 +341,7 @@ describe('vault env run (integration)', () => {
     expect(r.status).toBe(127);
   });
 
-  it('rejects --inject file without --out-file', () => {
+  it('rejects --inject file without a file target', () => {
     const r = cli([
       'run',
       'dev',
@@ -355,7 +355,52 @@ describe('vault env run (integration)', () => {
       '0',
     ]);
     expect(r.status).toBe(1);
-    expect(r.stdout + r.stderr).toMatch(/--out-file/);
+    expect(r.stdout + r.stderr).toMatch(/--export <path> is required/);
+  });
+
+  it('warns that --inject file is deprecated but still works (routed to --export)', () => {
+    const envFile = path.join(path.dirname(vaultPath), 'legacy-file.env');
+    const r = cli([
+      'run',
+      'dev',
+      '--inject',
+      'file',
+      '--out-file',
+      envFile,
+      '-v',
+      vaultPath,
+      '--',
+      ...PRINT_ENV,
+    ]);
+    expect(r.status).toBe(0);
+    // Deprecation warnings go to stderr, never stdout (stdout stays parseable).
+    expect(r.stderr).toMatch(/--inject file` is deprecated/);
+    expect(r.stderr).toMatch(/--out-file` is deprecated/);
+    const env = JSON.parse(r.stdout);
+    expect(env.API_URL).toBe('https://api.example.com'); // vault var injected
+    expect(env.VAULT_ENV_PASSWORD).toBeUndefined(); // clean isolation
+    expect(env.ENV_FILE_PATH).toBe(envFile); // pointer set
+    expect(fs.existsSync(envFile)).toBe(false); // deleted after exit
+  });
+
+  it('treats --out-file alone as a deprecated alias of --export', () => {
+    const envFile = path.join(path.dirname(vaultPath), 'legacy-outfile.env');
+    const r = cli([
+      'run',
+      'dev',
+      '--out-file',
+      envFile,
+      '-v',
+      vaultPath,
+      '--',
+      NODE,
+      '-e',
+      `process.stdout.write(require('fs').readFileSync(process.env.ENV_FILE_PATH,'utf8'))`,
+    ]);
+    expect(r.status).toBe(0);
+    expect(r.stderr).toMatch(/--out-file` is deprecated/);
+    expect(r.stdout).toContain('API_URL=https://api.example.com');
+    expect(fs.existsSync(envFile)).toBe(false);
   });
 
   it('errors when no command is given', () => {

--- a/src/__tests__/cli/envRun.integration.test.js
+++ b/src/__tests__/cli/envRun.integration.test.js
@@ -98,29 +98,50 @@ describe('vault env run (integration)', () => {
 
   it('file mode writes the env file, the child can read it, and it is deleted after', () => {
     const envFile = path.join(path.dirname(vaultPath), 'out.env');
-    const r = cli(
-      [
-        'run',
-        'dev',
-        '--inject',
-        'file',
-        '--out-file',
-        envFile,
-        '-v',
-        vaultPath,
-        '--',
-        NODE,
-        '-e',
-        // file mode inherits the parent env, so read the path from an env var
-        // (avoids ambiguity of passing it as a node script argument).
-        `process.stdout.write(require('fs').readFileSync(process.env.EF_PATH,'utf8'))`,
-      ],
-      { EF_PATH: envFile }
-    );
+    const r = cli([
+      'run',
+      'dev',
+      '--inject',
+      'file',
+      '--out-file',
+      envFile,
+      '-v',
+      vaultPath,
+      '--',
+      NODE,
+      '-e',
+      // File mode is now clean-isolated (vault vars are injected, but the
+      // parent env is NOT passed through), so the child cannot rely on an
+      // inherited env var to locate the file — read the literal path instead.
+      `process.stdout.write(require('fs').readFileSync(${JSON.stringify(envFile)},'utf8'))`,
+    ]);
     expect(r.status).toBe(0);
     // The child saw the decrypted vars via the file...
     expect(r.stdout).toContain('API_URL=https://api.example.com');
     // ...and the file is securely deleted once the child exits.
+    expect(fs.existsSync(envFile)).toBe(false);
+  });
+
+  it('file mode does not leak the parent env to the child (clean isolation)', () => {
+    const envFile = path.join(path.dirname(vaultPath), 'out2.env');
+    const r = cli([
+      'run',
+      'dev',
+      '--inject',
+      'file',
+      '--out-file',
+      envFile,
+      '-v',
+      vaultPath,
+      '--',
+      ...PRINT_ENV,
+    ]);
+    expect(r.status).toBe(0);
+    const env = JSON.parse(r.stdout);
+    // Vault vars are injected into the process env...
+    expect(env.API_URL).toBe('https://api.example.com');
+    // ...but the parent's password must NOT leak (was the file-mode bug).
+    expect(env.VAULT_ENV_PASSWORD).toBeUndefined();
     expect(fs.existsSync(envFile)).toBe(false);
   });
 

--- a/src/__tests__/cli/envRun.integration.test.js
+++ b/src/__tests__/cli/envRun.integration.test.js
@@ -145,6 +145,74 @@ describe('vault env run (integration)', () => {
     expect(fs.existsSync(envFile)).toBe(false);
   });
 
+  it('--export writes the file, sets ENV_FILE_PATH, injects clean vars, and deletes after', () => {
+    const envFile = path.join(path.dirname(vaultPath), 'exp.env');
+    const r = cli([
+      'run',
+      'dev',
+      '--export',
+      envFile,
+      '-v',
+      vaultPath,
+      '--',
+      NODE,
+      '-e',
+      // The child finds the file via ENV_FILE_PATH (no hardcoded path).
+      `const fs=require('fs');` +
+        `process.stdout.write('FILE:'+fs.readFileSync(process.env.ENV_FILE_PATH,'utf8'));` +
+        `process.stdout.write('ENVVAR:'+process.env.API_URL)`,
+    ]);
+    expect(r.status).toBe(0);
+    // File contains the resolved vars...
+    expect(r.stdout).toContain('FILE:');
+    expect(r.stdout).toContain('API_URL=https://api.example.com');
+    // ...and the vars are ALSO injected into the (clean) process env.
+    expect(r.stdout).toContain('ENVVAR:https://api.example.com');
+    // ENV_FILE_PATH points at the export path.
+    // File is securely deleted once the child exits.
+    expect(fs.existsSync(envFile)).toBe(false);
+  });
+
+  it('--export composes with --inject merge (file written + parent env inherited)', () => {
+    const envFile = path.join(path.dirname(vaultPath), 'exp-merge.env');
+    const r = cli([
+      'run',
+      'dev',
+      '--inject',
+      'merge',
+      '--export',
+      envFile,
+      '-v',
+      vaultPath,
+      '--',
+      ...PRINT_ENV,
+    ]);
+    expect(r.status).toBe(0);
+    const env = JSON.parse(r.stdout);
+    expect(env.API_URL).toBe('https://api.example.com'); // vault var
+    expect(env.VAULT_ENV_PASSWORD).toBe(PASSWORD); // inherited (merge)
+    expect(env.ENV_FILE_PATH).toBe(envFile); // pointer set
+    expect(fs.existsSync(envFile)).toBe(false); // deleted after exit
+  });
+
+  it('--export securely deletes the file even when the child fails', () => {
+    const envFile = path.join(path.dirname(vaultPath), 'exp-fail.env');
+    const r = cli([
+      'run',
+      'dev',
+      '--export',
+      envFile,
+      '-v',
+      vaultPath,
+      '--',
+      NODE,
+      '-e',
+      'process.exit(3)',
+    ]);
+    expect(r.status).toBe(3);
+    expect(fs.existsSync(envFile)).toBe(false);
+  });
+
   it('exits 127 when the command is not found', () => {
     const r = cli(['run', 'dev', '-v', vaultPath, '--', 'no-such-cmd-xyz-123']);
     expect(r.status).toBe(127);

--- a/src/__tests__/cli/envRun.integration.test.js
+++ b/src/__tests__/cli/envRun.integration.test.js
@@ -213,6 +213,49 @@ describe('vault env run (integration)', () => {
     expect(fs.existsSync(envFile)).toBe(false);
   });
 
+  it('--export refuses to overwrite an existing file without --force, leaving it intact', () => {
+    const envFile = path.join(path.dirname(vaultPath), 'existing.env');
+    fs.writeFileSync(envFile, 'PRECIOUS=keepme\n');
+    const r = cli([
+      'run',
+      'dev',
+      '--export',
+      envFile,
+      '-v',
+      vaultPath,
+      '--',
+      NODE,
+      '-e',
+      '0',
+    ]);
+    expect(r.status).toBe(1);
+    expect(r.stdout + r.stderr).toMatch(/Refusing to overwrite/i);
+    // The pre-existing file must NOT be touched or deleted.
+    expect(fs.existsSync(envFile)).toBe(true);
+    expect(fs.readFileSync(envFile, 'utf8')).toBe('PRECIOUS=keepme\n');
+    fs.rmSync(envFile);
+  });
+
+  it('--export --force overwrites an existing file and securely deletes it after', () => {
+    const envFile = path.join(path.dirname(vaultPath), 'existing2.env');
+    fs.writeFileSync(envFile, 'OLD=stuff\n');
+    const r = cli([
+      'run',
+      'dev',
+      '--export',
+      envFile,
+      '--force',
+      '-v',
+      vaultPath,
+      '--',
+      NODE,
+      '-e',
+      '0',
+    ]);
+    expect(r.status).toBe(0);
+    expect(fs.existsSync(envFile)).toBe(false);
+  });
+
   it('exits 127 when the command is not found', () => {
     const r = cli(['run', 'dev', '-v', vaultPath, '--', 'no-such-cmd-xyz-123']);
     expect(r.status).toBe(127);

--- a/src/__tests__/cli/envRunHelpers.test.js
+++ b/src/__tests__/cli/envRunHelpers.test.js
@@ -11,6 +11,7 @@ import {
   buildChildEnv,
   toDotenv,
   parseAllowlist,
+  parseSetPairs,
   readAllowlistFile,
   loadProjectConfig,
   applyProjectConfig,
@@ -118,6 +119,36 @@ describe('toDotenv <-> parseEnvFile round-trip', () => {
       BACKSLASH: 'a\\b',
     };
     expect(EnvironmentVault.parseEnvFile(toDotenv(obj))).toEqual(obj);
+  });
+});
+
+describe('parseSetPairs', () => {
+  it('parses KEY=VALUE pairs into an object', () => {
+    expect(parseSetPairs(['A=1', 'B=two'])).toEqual({ A: '1', B: 'two' });
+  });
+
+  it('keeps everything after the first = in the value', () => {
+    expect(parseSetPairs(['URL=postgres://h?ssl=true'])).toEqual({
+      URL: 'postgres://h?ssl=true',
+    });
+  });
+
+  it('allows an empty value', () => {
+    expect(parseSetPairs(['EMPTY='])).toEqual({ EMPTY: '' });
+  });
+
+  it('later pairs override earlier ones', () => {
+    expect(parseSetPairs(['K=1', 'K=2'])).toEqual({ K: '2' });
+  });
+
+  it('returns {} for no pairs', () => {
+    expect(parseSetPairs()).toEqual({});
+    expect(parseSetPairs([])).toEqual({});
+  });
+
+  it('throws on a pair without = or with an empty key', () => {
+    expect(() => parseSetPairs(['NOEQUALS'])).toThrow(/expected KEY=VALUE/);
+    expect(() => parseSetPairs(['=value'])).toThrow(/expected KEY=VALUE/);
   });
 });
 

--- a/src/__tests__/cli/envRunHelpers.test.js
+++ b/src/__tests__/cli/envRunHelpers.test.js
@@ -64,11 +64,14 @@ describe('buildChildEnv', () => {
     expect(env.PATH).toBe('/vault/path');
   });
 
-  it('file mode injects no vault vars (they go to the file)', () => {
+  it('treats the legacy "file" mode as clean: vault vars injected, parent env not leaked', () => {
+    // file is no longer a population mode (writing a file is orthogonal).
+    // Any non-merge mode must inject vault vars and keep clean isolation —
+    // the old behavior (no vault vars + full parent passthrough) was the bug.
     const env = buildChildEnv({ mode: 'file', vars, parentEnv });
-    expect(env.API_URL).toBeUndefined();
-    expect(env.TOKEN).toBeUndefined();
-    expect(env.SECRET_FROM_PARENT).toBe('leak'); // still inherits parent
+    expect(env.API_URL).toBe('https://x'); // now injected
+    expect(env.TOKEN).toBe('abc');
+    expect(env.SECRET_FROM_PARENT).toBeUndefined(); // not leaked
   });
 
   it('CLEAN_ALLOWLIST covers the documented system vars', () => {

--- a/src/__tests__/cli/envRunHelpers.test.js
+++ b/src/__tests__/cli/envRunHelpers.test.js
@@ -10,6 +10,7 @@ import {
   VAULTRC_FILENAME,
   buildChildEnv,
   toDotenv,
+  quoteDotenvValue,
   parseAllowlist,
   parseSetPairs,
   readAllowlistFile,
@@ -103,6 +104,31 @@ describe('toDotenv', () => {
     expect(toDotenv({ K: 'has "quote"' })).toBe('K="has \\"quote\\""\n');
     expect(toDotenv({ K: ' padded ' })).toBe('K=" padded "\n');
     expect(toDotenv({ K: 'a\\b' })).toBe('K=a\\b\n'); // backslash alone: not quoted
+  });
+});
+
+describe('quoteDotenvValue', () => {
+  it('leaves plain values and the empty string unquoted', () => {
+    expect(quoteDotenvValue('plain')).toBe('plain');
+    expect(quoteDotenvValue('a b c')).toBe('a b c'); // middle spaces ok
+    expect(quoteDotenvValue('')).toBe('');
+  });
+
+  it('coerces null/undefined to an empty string', () => {
+    expect(quoteDotenvValue(null)).toBe('');
+    expect(quoteDotenvValue(undefined)).toBe('');
+  });
+
+  it('does not quote a value whose only special char is a backslash', () => {
+    expect(quoteDotenvValue('a\\b')).toBe('a\\b');
+  });
+
+  it('quotes and escapes carriage returns, quotes, # and edge whitespace', () => {
+    expect(quoteDotenvValue('a\rb')).toBe('"a\\rb"');
+    expect(quoteDotenvValue("'")).toBe('"\'"'); // single quote triggers quoting
+    expect(quoteDotenvValue('a#b')).toBe('"a#b"');
+    expect(quoteDotenvValue(' lead')).toBe('" lead"');
+    expect(quoteDotenvValue('a"b')).toBe('"a\\"b"');
   });
 });
 

--- a/src/__tests__/cli/envRunHelpers.test.js
+++ b/src/__tests__/cli/envRunHelpers.test.js
@@ -17,6 +17,7 @@ import {
   extractRunCommand,
   getRunCommand,
 } from '../../../bin/commands/envRunHelpers.js';
+import { EnvironmentVault } from '../../electron/models/EnvironmentVault.js';
 
 describe('buildChildEnv', () => {
   const parentEnv = {
@@ -82,12 +83,41 @@ describe('buildChildEnv', () => {
 });
 
 describe('toDotenv', () => {
-  it('serializes key/value pairs with a trailing newline', () => {
+  it('serializes plain key/value pairs unquoted with a trailing newline', () => {
     expect(toDotenv({ A: '1', B: 'two' })).toBe('A=1\nB=two\n');
   });
 
   it('handles an empty map', () => {
     expect(toDotenv({})).toBe('\n');
+  });
+
+  it('leaves middle spaces and = signs unquoted', () => {
+    expect(toDotenv({ A: 'a b', DB: 'postgres://h?ssl=true' })).toBe(
+      'A=a b\nDB=postgres://h?ssl=true\n'
+    );
+  });
+
+  it('double-quotes and escapes values with newlines, quotes, # or edge whitespace', () => {
+    expect(toDotenv({ K: 'line1\nline2#x' })).toBe('K="line1\\nline2#x"\n');
+    expect(toDotenv({ K: 'has "quote"' })).toBe('K="has \\"quote\\""\n');
+    expect(toDotenv({ K: ' padded ' })).toBe('K=" padded "\n');
+    expect(toDotenv({ K: 'a\\b' })).toBe('K=a\\b\n'); // backslash alone: not quoted
+  });
+});
+
+describe('toDotenv <-> parseEnvFile round-trip', () => {
+  it('round-trips tricky values unchanged (write with toDotenv, read with parseEnvFile)', () => {
+    const obj = {
+      SIMPLE: 'value',
+      WITH_SPACES: 'a b c',
+      WITH_HASH: 'color#fff',
+      MULTILINE: 'line1\nline2',
+      WITH_QUOTE: 'say "hi"',
+      PADDED: '  pad  ',
+      URL: 'postgres://u:p@h:5432/db?ssl=true',
+      BACKSLASH: 'a\\b',
+    };
+    expect(EnvironmentVault.parseEnvFile(toDotenv(obj))).toEqual(obj);
   });
 });
 

--- a/src/__tests__/electron/models/EnvironmentVault.test.js
+++ b/src/__tests__/electron/models/EnvironmentVault.test.js
@@ -353,6 +353,26 @@ describe('EnvironmentVault', () => {
       const result = EnvironmentVault.parseEnvFile('JUST_A_COMMENT\nKEY=val');
       expect(result).toEqual({ KEY: 'val' });
     });
+
+    it('decodes escapes inside double-quoted values', () => {
+      const result = EnvironmentVault.parseEnvFile(
+        'K="line1\\nline2#x"\nQ="has \\"quote\\""'
+      );
+      expect(result).toEqual({
+        K: 'line1\nline2#x',
+        Q: 'has "quote"',
+      });
+    });
+
+    it('preserves edge whitespace in double-quoted values', () => {
+      const result = EnvironmentVault.parseEnvFile('K=" padded "');
+      expect(result).toEqual({ K: ' padded ' });
+    });
+
+    it('treats single-quoted values as literal (no escape decoding)', () => {
+      const result = EnvironmentVault.parseEnvFile("K='a\\nb'");
+      expect(result).toEqual({ K: 'a\\nb' });
+    });
   });
 
   describe('importFromEnvFile', () => {

--- a/src/__tests__/electron/services/EnvironmentVaultService.test.js
+++ b/src/__tests__/electron/services/EnvironmentVaultService.test.js
@@ -955,6 +955,30 @@ describe('EnvironmentVaultService', () => {
       expect(result.success).toBe(true);
       expect(result.data).toEqual({ A: '1', B: '2' });
     });
+
+    it('should quote/escape special values in dotenv format', async () => {
+      const vault = createPopulatedVault(testEnvName, {
+        M: 'line1\nline2#x',
+        P: ' pad ',
+      });
+      await EnvironmentVaultService.createVault(
+        testVaultPath,
+        testPassword,
+        vault.toJSON()
+      );
+      const file = fsMock.writeJSON.mock.calls[0][1];
+      fsMock.pathExists.mockResolvedValue(true);
+      fsMock.readJSON.mockResolvedValue(file);
+
+      const result = await EnvironmentVaultService.exportEnv(
+        testVaultPath,
+        testPassword,
+        testEnvName
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe('M="line1\\nline2#x"\nP=" pad "\n');
+    });
   });
 
   describe('templateEnv', () => {

--- a/src/electron/models/EnvironmentVault.js
+++ b/src/electron/models/EnvironmentVault.js
@@ -299,10 +299,22 @@ export class EnvironmentVault {
       const key = match[1];
       let value = match[2];
 
-      if (
-        (value.startsWith('"') && value.endsWith('"')) ||
-        (value.startsWith("'") && value.endsWith("'"))
-      ) {
+      const isDoubleQuoted =
+        value.length >= 2 && value.startsWith('"') && value.endsWith('"');
+      const isSingleQuoted =
+        value.length >= 2 && value.startsWith("'") && value.endsWith("'");
+
+      if (isDoubleQuoted) {
+        // Decode the escapes written by toDotenv()/quoteDotenvValue():
+        // \n \r \t -> control chars; \" \\ -> the literal char.
+        value = value.slice(1, -1).replace(/\\([\\nrt"])/g, (_, c) => {
+          if (c === 'n') return '\n';
+          if (c === 'r') return '\r';
+          if (c === 't') return '\t';
+          return c; // \" -> "  and  \\ -> \
+        });
+      } else if (isSingleQuoted) {
+        // Single quotes are literal (no escape processing).
         value = value.slice(1, -1);
       }
 

--- a/src/electron/services/EnvironmentVaultService.js
+++ b/src/electron/services/EnvironmentVaultService.js
@@ -13,6 +13,7 @@ const SUSPICIOUS_VALUE_RE =
   /-----BEGIN |sk_live_|AKIA[0-9A-Z]{16}|[0-9a-f]{64,}/;
 import { validatePasswordStrength } from '../utils/passwordValidation.js';
 import { getAppDataPath, getEnvsDir } from '../utils/appPaths.js';
+import { toDotenv } from '../../utils/dotenv.js';
 
 function resolvePath(...segments) {
   return process.platform === 'win32'
@@ -568,11 +569,7 @@ export class EnvironmentVaultService {
         return { success: true, data: vars };
       }
 
-      const lines = Object.entries(vars).map(
-        ([key, value]) => `${key}=${value}`
-      );
-
-      return { success: true, data: lines.join('\n') + '\n' };
+      return { success: true, data: toDotenv(vars) };
     } catch (error) {
       return { success: false, error: error.message };
     }

--- a/src/utils/dotenv.js
+++ b/src/utils/dotenv.js
@@ -1,0 +1,36 @@
+/**
+ * Shared dotenv serialization used by both the CLI runner (`vault env run
+ * --export`) and `vault env export`. The escaping here is the matched pair of
+ * the reader in EnvironmentVault.parseEnvFile — values written by toDotenv()
+ * round-trip back through `vault env import` unchanged.
+ */
+
+/**
+ * Quote/escape a single dotenv value so it survives the line-based parser
+ * (EnvironmentVault.parseEnvFile) unchanged. A value is double-quoted with
+ * \\, \", \n, \r escaped when it would otherwise be corrupted unquoted —
+ * i.e. it contains a newline or quote char, a `#`, or has leading/trailing
+ * whitespace (which the parser would trim away). Plain values are emitted raw.
+ */
+export function quoteDotenvValue(value) {
+  const str = value == null ? '' : String(value);
+  const needsQuoting =
+    str !== '' &&
+    (str !== str.trim() || /[\n\r"']/.test(str) || str.includes('#'));
+  if (!needsQuoting) return str;
+  const escaped = str
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r');
+  return `"${escaped}"`;
+}
+
+/** Serialize a key/value map to dotenv format (values quoted/escaped as needed). */
+export function toDotenv(vars) {
+  return (
+    Object.entries(vars)
+      .map(([key, value]) => `${key}=${quoteDotenvValue(value)}`)
+      .join('\n') + '\n'
+  );
+}


### PR DESCRIPTION
## Summary

TL;DR; This PR introduces `--export` flag, which writes the resolved environment to a
0600 temp .env, sets ENV_FILE_PATH so the child can locate it, and securely
deletes it on exit — independent of the clean|merge population mode. This
decouples file delivery from `--inject` and lets users get clean-isolated
process env AND an on-disk file at once.

The resolved write path is unified: the legacy `--inject file --out-file`
is routed through the same logic (and now also sets ENV_FILE_PATH, fixing
the missing-pointer divergence from SPEC §11.3). Escaping, an overwrite
guard, user-supplied vars, and deprecating the legacy flags follow next.