### PR TITLE
Feat/env templating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ config.bat
 # agents configs
 .agentsrc
 
+# docs
+*.pdf
+*.docx

--- a/bin/commands/env.js
+++ b/bin/commands/env.js
@@ -32,6 +32,8 @@ import {
 import {
   parseFileMode,
   decodeValue,
+  encodeValue,
+  ENCODERS,
   writeArtifact,
   normalizeManifest,
   renderDeliverEntry,
@@ -465,6 +467,8 @@ export function registerEnvCommand(program) {
     .option('--password-file <path>', 'Read vault password from a file')
     .option('--password-stdin', 'Read vault password from stdin')
     .option('-e, --env <name>', 'Environment name (or set VAULT_ENV)')
+    .option('--in <path>', 'Read the value from a file instead of the argument')
+    .option('--encode <codec>', 'Encode the value before storing (base64)')
     .option('--public', 'Mark variable as non-sensitive')
     .option('--required', 'Mark variable as required (checked by validate)')
     .option('--extends <parent>', 'Set this environment to extend <parent>')
@@ -472,10 +476,33 @@ export function registerEnvCommand(program) {
     .option('--description <text>', 'Set environment description')
     .action(async (key, value, options) => {
       try {
-        if (value === undefined && !process.stdin.isTTY) {
+        // Validate --encode before touching the vault so a typo fails fast.
+        if (options.encode && !ENCODERS.includes(options.encode)) {
           console.error(
             chalk.red(
-              'No value provided. Pass a value argument when running non-interactively.'
+              `Unknown encode "${options.encode}" (supported: ${ENCODERS.join(', ')})`
+            )
+          );
+          process.exit(1);
+        }
+        if (options.in !== undefined && value !== undefined) {
+          console.error(
+            chalk.red(
+              'Provide either a value argument or --in <path>, not both.'
+            )
+          );
+          process.exit(1);
+        }
+
+        const fromFile = options.in !== undefined;
+        // The editor is only for the "no value, no file" interactive case.
+        const interactive = value === undefined && !fromFile;
+
+        if (interactive && !process.stdin.isTTY) {
+          console.error(
+            chalk.red(
+              'No value provided. Pass a value argument or --in <path> ' +
+                'when running non-interactively.'
             )
           );
           process.exit(1);
@@ -484,7 +511,20 @@ export function registerEnvCommand(program) {
         const { vaultPath, vaultPassword, vault } = await loadVault(options);
         const envName = requireEnvName(options.env);
 
-        if (value === undefined) {
+        if (fromFile) {
+          // Ingest a file as the value — base64 for binary blobs (Firebase
+          // plists, keystores) that `env file --decode` later materializes.
+          let buf;
+          try {
+            buf = await fs.readFile(options.in);
+          } catch (err) {
+            console.error(
+              chalk.red(`Cannot read --in file "${options.in}": ${err.message}`)
+            );
+            process.exit(1);
+          }
+          value = encodeValue(buf, options.encode);
+        } else if (interactive) {
           let previousValue;
           try {
             previousValue = vault.getActiveVersion(envName)?.vars?.[key];
@@ -498,6 +538,9 @@ export function registerEnvCommand(program) {
             log(chalk.yellow('Empty value — nothing changed.'));
             return;
           }
+        } else if (options.encode) {
+          // Encode an inline value argument too (symmetry with --in).
+          value = encodeValue(value, options.encode);
         }
 
         const spinner = oraQuiet(`Setting ${key}...`).start();
@@ -891,7 +934,13 @@ export function registerEnvCommand(program) {
           process.exit(1);
         }
         const vars = result.data;
-        const readTemplate = (p) => fs.readFileSync(resolvePath(p), 'utf-8');
+        const readTemplate = (p) => {
+          try {
+            return fs.readFileSync(resolvePath(p), 'utf-8');
+          } catch (err) {
+            throw new Error(`Cannot read template "${p}": ${err.message}`);
+          }
+        };
 
         for (const entry of manifest.entries) {
           // Render first (validates missing vars / templates) so a dry run is a

--- a/bin/commands/env.js
+++ b/bin/commands/env.js
@@ -18,6 +18,7 @@ import {
   parseSetPairs,
   readAllowlistFile,
   loadProjectConfig,
+  findProjectConfig,
   applyProjectConfig,
   secureDelete,
   cleanupOrphanTempDirs,
@@ -28,6 +29,13 @@ import {
   parseEditorContent,
   openInEditor,
 } from './envEditHelpers.js';
+import {
+  parseFileMode,
+  decodeValue,
+  writeArtifact,
+  normalizeManifest,
+  renderDeliverEntry,
+} from './envDeliverHelpers.js';
 // Password-resolution helpers live in src/utils/password.js so they can be unit
 // tested without importing the CLI entry tree (SPEC.md §16.7). Imported here for
 // internal use and re-exported below for the command layer / existing importers.
@@ -785,6 +793,162 @@ export function registerEnvCommand(program) {
           await copyToClipboard(text, 'export');
         }
         console.log(text);
+      } catch (error) {
+        console.error(chalk.red(error.message));
+        process.exit(1);
+      }
+    });
+
+  env
+    .command('file')
+    .description('Materialize a single variable to a file (optionally decoded)')
+    .argument('<key>', 'Variable name to materialize')
+    .requiredOption('-o, --out <path>', 'Destination file path')
+    .option('-e, --env <name>', 'Environment name (or set VAULT_ENV)')
+    .option('--decode <codec>', 'Decode the value before writing (base64)')
+    .option('--mode <octal>', 'File mode for the written file', '0600')
+    .option('-n, --name <name>', 'Vault name')
+    .option('-v, --vault <path>', 'Exact vault file path')
+    .option('--password <password>', 'Vault password (non-interactive)')
+    .option('--password-file <path>', 'Read vault password from a file')
+    .option('--password-stdin', 'Read vault password from stdin')
+    .action(async (key, options) => {
+      try {
+        // Parse the mode before touching the vault so a bad --mode fails fast.
+        const mode = parseFileMode(options.mode);
+        const { vaultPath, vaultPassword } = await loadVault(options);
+        const envName = requireEnvName(options.env);
+
+        const result = await EnvironmentVaultService.getEnv(
+          vaultPath,
+          vaultPassword,
+          envName,
+          key
+        );
+        if (!result.success) {
+          console.error(chalk.red(result.error));
+          process.exit(1);
+        }
+
+        const content = decodeValue(result.data.value, options.decode);
+        await writeArtifact(options.out, content, { mode });
+        console.log(
+          chalk.green(
+            `Wrote ${chalk.cyan(key)} → ${options.out} (mode ${options.mode})`
+          )
+        );
+      } catch (error) {
+        console.error(chalk.red(error.message));
+        process.exit(1);
+      }
+    });
+
+  env
+    .command('apply')
+    .description(
+      'Write every artifact declared in the .vaultrc delivery manifest'
+    )
+    .argument('[envName]', 'Environment (or .vaultrc "env" / VAULT_ENV)')
+    .option('-n, --name <name>', 'Vault name')
+    .option('-v, --vault <path>', 'Exact vault file path')
+    .option('--password <password>', 'Vault password (non-interactive)')
+    .option('--password-file <path>', 'Read vault password from a file')
+    .option('--password-stdin', 'Read vault password from stdin')
+    .option('--dry-run', 'Resolve and render, but write nothing')
+    .action(async (envArg, options) => {
+      try {
+        // Artifact paths are relative to the .vaultrc directory, so `apply`
+        // behaves the same from the project root or any subdirectory.
+        const { config, dir } = findProjectConfig();
+        const manifest = normalizeManifest(config);
+        if (manifest.entries.length === 0) {
+          console.error(
+            chalk.red(
+              'No delivery manifest found — add a "deliver" array to .vaultrc.'
+            )
+          );
+          process.exit(1);
+        }
+        const baseDir = dir || process.cwd();
+        const resolvePath = (p) =>
+          path.isAbsolute(p) ? p : path.join(baseDir, p);
+
+        const envName = requireEnvName(envArg ?? manifest.env);
+        // Let .vaultrc supply vault/name when not given on the CLI.
+        const { vaultPath, vaultPassword } = await loadVault({
+          ...options,
+          vault: options.vault ?? config.vault,
+          name: options.name ?? config.name,
+        });
+        const result = await EnvironmentVaultService.exportEnv(
+          vaultPath,
+          vaultPassword,
+          envName,
+          'json'
+        );
+        if (!result.success) {
+          console.error(chalk.red(result.error));
+          process.exit(1);
+        }
+        const vars = result.data;
+        const readTemplate = (p) => fs.readFileSync(resolvePath(p), 'utf-8');
+
+        for (const entry of manifest.entries) {
+          // Render first (validates missing vars / templates) so a dry run is a
+          // real pre-flight check, not just a path listing.
+          const content = renderDeliverEntry(entry, vars, readTemplate);
+          if (options.dryRun) {
+            console.log(
+              chalk.gray(`would write ${entry.path} (${entry.kind})`)
+            );
+            continue;
+          }
+          await writeArtifact(resolvePath(entry.path), content, {
+            mode: entry.mode,
+          });
+          console.log(chalk.green(`wrote ${entry.path}`));
+        }
+      } catch (error) {
+        console.error(chalk.red(error.message));
+        process.exit(1);
+      }
+    });
+
+  env
+    .command('clean')
+    .description('Securely remove artifacts declared in the .vaultrc manifest')
+    .option('--dry-run', 'Show what would be removed, but remove nothing')
+    .action(async (options) => {
+      try {
+        const { config, dir } = findProjectConfig();
+        const manifest = normalizeManifest(config);
+        if (manifest.entries.length === 0) {
+          console.error(
+            chalk.red(
+              'No delivery manifest found — add a "deliver" array to .vaultrc.'
+            )
+          );
+          process.exit(1);
+        }
+        const baseDir = dir || process.cwd();
+        const resolvePath = (p) =>
+          path.isAbsolute(p) ? p : path.join(baseDir, p);
+
+        let removed = 0;
+        for (const entry of manifest.entries) {
+          const outPath = resolvePath(entry.path);
+          if (!fs.existsSync(outPath)) continue;
+          if (options.dryRun) {
+            console.log(chalk.gray(`would remove ${entry.path}`));
+            continue;
+          }
+          secureDelete(outPath);
+          console.log(chalk.green(`removed ${entry.path}`));
+          removed += 1;
+        }
+        if (!options.dryRun && removed === 0) {
+          console.log(chalk.gray('nothing to remove'));
+        }
       } catch (error) {
         console.error(chalk.red(error.message));
         process.exit(1);

--- a/bin/commands/envDeliverHelpers.js
+++ b/bin/commands/envDeliverHelpers.js
@@ -41,6 +41,26 @@ export function decodeValue(value, decode) {
   throw new Error(`Unknown decode "${decode}" (supported: base64)`);
 }
 
+/** Codecs a stored value may be encoded with on the way in (`set --encode`). */
+export const ENCODERS = ['base64'];
+
+/**
+ * Encode raw bytes (or a string) into a storable string value — the inverse of
+ * decodeValue, used by `set --in --encode` to ingest a file as a vault var.
+ * Vault values are strings, so this always returns a string: the base64 text
+ * for binary blobs, or the UTF-8 text when no encoding is requested.
+ */
+export function encodeValue(input, encode) {
+  const buf = Buffer.isBuffer(input)
+    ? input
+    : Buffer.from(input == null ? '' : String(input), 'utf-8');
+  if (!encode) return buf.toString('utf-8');
+  if (encode === 'base64') return buf.toString('base64');
+  throw new Error(
+    `Unknown encode "${encode}" (supported: ${ENCODERS.join(', ')})`
+  );
+}
+
 /**
  * Write delivered content to `outPath`, creating the parent directory if needed.
  * The file mode is enforced with an explicit chmod so it is deterministic even

--- a/bin/commands/envDeliverHelpers.js
+++ b/bin/commands/envDeliverHelpers.js
@@ -1,0 +1,224 @@
+import path from 'path';
+import fs from 'fs-extra';
+
+import { toDotenv } from '../../src/utils/dotenv.js';
+import { renderTemplate } from '../../src/utils/templating.js';
+
+/**
+ * Delivery helpers shared by `vault env file` (single-var blob) and
+ * `vault env apply` (manifest fan-out). These are the "materialize a secret to a
+ * real file on disk" primitives — distinct from `run --export`, whose temp file
+ * is wiped on child exit. Delivered files persist for the build tool to consume;
+ * cleanup is the caller's concern (`vault env clean` / manual).
+ */
+
+/** Default mode for a delivered secret file: owner read/write only. */
+export const DEFAULT_FILE_MODE = 0o600;
+
+/**
+ * Parse an octal file-mode string ("0600", "600", "0o600") into a number.
+ * A number is passed through. Throws on anything that is not 3–4 octal digits.
+ */
+export function parseFileMode(input) {
+  if (input == null) return DEFAULT_FILE_MODE;
+  if (typeof input === 'number') return input;
+  const s = String(input).trim().replace(/^0o/i, '');
+  if (!/^[0-7]{3,4}$/.test(s)) {
+    throw new Error(`Invalid file mode "${input}" (expected octal, e.g. 0600)`);
+  }
+  return parseInt(s, 8);
+}
+
+/**
+ * Decode a resolved value per a `decode` directive. Returns a Buffer for decoded
+ * (binary-capable) content, or the raw string when no decode is requested.
+ * `base64` is the only codec today; extend here (never at the call site).
+ */
+export function decodeValue(value, decode) {
+  const str = value == null ? '' : String(value);
+  if (!decode) return str;
+  if (decode === 'base64') return Buffer.from(str, 'base64');
+  throw new Error(`Unknown decode "${decode}" (supported: base64)`);
+}
+
+/**
+ * Write delivered content to `outPath`, creating the parent directory if needed.
+ * The file mode is enforced with an explicit chmod so it is deterministic even
+ * when overwriting a pre-existing file (whose mode `writeFile` would keep) and
+ * regardless of umask. Parent-directory permissions are intentionally left
+ * alone — artifacts land in real project dirs (e.g. `ios/`), not a private temp
+ * dir (that 0700 story belongs to v2 mount).
+ *
+ * @param {string} outPath
+ * @param {string|Buffer} content
+ * @param {{ mode?: number }} [opts]
+ * @returns {Promise<string>} the written path.
+ */
+export async function writeArtifact(
+  outPath,
+  content,
+  { mode = DEFAULT_FILE_MODE } = {}
+) {
+  await fs.ensureDir(path.dirname(path.resolve(outPath)));
+  await fs.writeFile(outPath, content, { mode });
+  await fs.chmod(outPath, mode);
+  return outPath;
+}
+
+// ---------------------------------------------------------------------------
+// Delivery manifest (.vaultrc "deliver") — SPEC §8.5 / MOBILE-INTEGRATION-GAPS §4.F
+// ---------------------------------------------------------------------------
+
+/** Output formats vault serializes natively (it owns dotenv; json is trivial). */
+export const DELIVER_FORMATS = ['dotenv', 'json'];
+/** Codecs a `from` (blob) entry may decode with. */
+export const DECODERS = ['base64'];
+
+const KIND_FIELDS = ['format', 'from', 'template'];
+
+/**
+ * Validate and normalize a single `deliver[]` entry. Exactly one of `format`,
+ * `from`, or `template` selects the kind:
+ *
+ * - `format` (+ optional `keys` subset) — serialize resolved vars natively.
+ * - `from` (+ optional `decode`) — a single var's value as a blob.
+ * - `template` (+ optional `out`) — render a `.vtpl`; `out` defaults to the
+ *   template path minus its `.vtpl` suffix.
+ *
+ * Returns a normalized entry `{ kind, path, mode, ... }` where `path` is the
+ * declared (still-relative) output path. Throws with a `deliver[i]:` prefix on
+ * any structural problem so the manifest fails loudly, never silently.
+ */
+export function normalizeDeliverEntry(entry, index = 0) {
+  const where = `deliver[${index}]`;
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+    throw new Error(`${where}: entry must be an object`);
+  }
+
+  const kinds = KIND_FIELDS.filter((k) => entry[k] !== undefined);
+  if (kinds.length !== 1) {
+    throw new Error(
+      `${where}: exactly one of "format", "from", "template" is required ` +
+        `(got ${kinds.length ? kinds.join(', ') : 'none'})`
+    );
+  }
+  const kind = kinds[0];
+  const mode =
+    entry.mode !== undefined ? parseFileMode(entry.mode) : DEFAULT_FILE_MODE;
+
+  if (kind === 'template') {
+    if (typeof entry.template !== 'string' || !entry.template) {
+      throw new Error(`${where}: "template" must be a non-empty path`);
+    }
+    let outPath = entry.out;
+    if (!outPath) {
+      if (entry.template.endsWith('.vtpl')) {
+        outPath = entry.template.slice(0, -'.vtpl'.length);
+      } else {
+        throw new Error(
+          `${where}: template "${entry.template}" has no .vtpl suffix to strip; ` +
+            `specify an explicit "out"`
+        );
+      }
+    }
+    return { kind, template: entry.template, path: outPath, mode };
+  }
+
+  if (typeof entry.path !== 'string' || !entry.path) {
+    throw new Error(`${where}: "path" is required`);
+  }
+
+  if (kind === 'format') {
+    if (!DELIVER_FORMATS.includes(entry.format)) {
+      throw new Error(
+        `${where}: unknown format "${entry.format}" ` +
+          `(supported: ${DELIVER_FORMATS.join(', ')})`
+      );
+    }
+    if (
+      entry.keys !== undefined &&
+      (!Array.isArray(entry.keys) ||
+        entry.keys.some((k) => typeof k !== 'string'))
+    ) {
+      throw new Error(`${where}: "keys" must be an array of strings`);
+    }
+    return {
+      kind,
+      path: entry.path,
+      format: entry.format,
+      keys: entry.keys || null,
+      mode,
+    };
+  }
+
+  // from (blob)
+  if (typeof entry.from !== 'string' || !entry.from) {
+    throw new Error(`${where}: "from" must be a variable name`);
+  }
+  if (entry.decode !== undefined && !DECODERS.includes(entry.decode)) {
+    throw new Error(
+      `${where}: unknown decode "${entry.decode}" ` +
+        `(supported: ${DECODERS.join(', ')})`
+    );
+  }
+  return {
+    kind,
+    path: entry.path,
+    from: entry.from,
+    decode: entry.decode || null,
+    mode,
+  };
+}
+
+/**
+ * Validate a whole `.vaultrc` config's delivery manifest. Returns
+ * `{ env, entries }` — `env` is the manifest's default environment (may be
+ * undefined), `entries` are normalized. An absent `deliver` yields an empty
+ * list; a non-array `deliver` throws.
+ */
+export function normalizeManifest(config = {}) {
+  const deliver = config.deliver;
+  if (deliver === undefined) return { env: config.env, entries: [] };
+  if (!Array.isArray(deliver)) {
+    throw new Error('.vaultrc "deliver" must be an array');
+  }
+  return {
+    env: config.env,
+    entries: deliver.map((e, i) => normalizeDeliverEntry(e, i)),
+  };
+}
+
+function pickKeys(vars, keys) {
+  const out = {};
+  for (const k of keys) {
+    if (!Object.prototype.hasOwnProperty.call(vars, k)) {
+      throw new Error(`deliver: key "${k}" not found in environment`);
+    }
+    out[k] = vars[k];
+  }
+  return out;
+}
+
+/**
+ * Produce the content for one normalized entry given the resolved `vars` map.
+ * `readTemplate(path)` is injected (returns the template text) so this stays a
+ * pure transform and is unit-testable without disk I/O. Returns a string, or a
+ * Buffer for base64-decoded blobs.
+ */
+export function renderDeliverEntry(entry, vars, readTemplate) {
+  if (entry.kind === 'from') {
+    if (!Object.prototype.hasOwnProperty.call(vars, entry.from)) {
+      throw new Error(
+        `deliver: variable "${entry.from}" not found in environment`
+      );
+    }
+    return decodeValue(vars[entry.from], entry.decode);
+  }
+  if (entry.kind === 'format') {
+    const subset = entry.keys ? pickKeys(vars, entry.keys) : vars;
+    if (entry.format === 'json') return `${JSON.stringify(subset, null, 2)}\n`;
+    return toDotenv(subset);
+  }
+  // template
+  return renderTemplate(readTemplate(entry.template), vars);
+}

--- a/bin/commands/envRunHelpers.js
+++ b/bin/commands/envRunHelpers.js
@@ -143,10 +143,15 @@ const VAULTRC_KEYS = ['inject', 'env', 'name', 'vault', 'allowlistFile'];
 
 /**
  * Walk from startDir upward looking for a .vaultrc file, stopping at a git
- * root (presence of .git) or the filesystem root. Returns the parsed config
- * object, or {} if no file is found. Throws on JSON parse errors.
+ * root (presence of .git) or the filesystem root. Returns `{ config, dir }`
+ * where `dir` is the directory the file was found in (null when none was
+ * found — `config` is then `{}`). Throws on read / JSON parse errors.
+ *
+ * `dir` matters for the delivery manifest: artifact paths are resolved relative
+ * to the .vaultrc location, not the current working directory, so `apply`/`clean`
+ * behave the same whether invoked from the project root or a subdirectory.
  */
-export function loadProjectConfig(startDir = process.cwd()) {
+export function findProjectConfig(startDir = process.cwd()) {
   let dir = path.resolve(startDir);
   while (true) {
     const candidate = path.join(dir, VAULTRC_FILENAME);
@@ -158,7 +163,7 @@ export function loadProjectConfig(startDir = process.cwd()) {
         throw new Error(`Cannot read ${candidate}: ${err.message}`);
       }
       try {
-        return JSON.parse(raw);
+        return { config: JSON.parse(raw), dir };
       } catch (err) {
         throw new Error(`Invalid JSON in ${candidate}: ${err.message}`);
       }
@@ -169,7 +174,15 @@ export function loadProjectConfig(startDir = process.cwd()) {
     if (parent === dir) break;
     dir = parent;
   }
-  return {};
+  return { config: {}, dir: null };
+}
+
+/**
+ * Convenience wrapper returning just the parsed config (or {} if none found).
+ * Preserves the original `loadProjectConfig` contract for existing callers.
+ */
+export function loadProjectConfig(startDir = process.cwd()) {
+  return findProjectConfig(startDir).config;
 }
 
 /**

--- a/docs/environments/MOBILE-INTEGRATION-GAPS.md
+++ b/docs/environments/MOBILE-INTEGRATION-GAPS.md
@@ -1,0 +1,430 @@
+# Mobile IDE Integration — Gap Analysis
+
+> **Scope**: What `secure-vault` needs to deliver secrets cleanly into **iOS
+> (Xcode)** and **Android (Android Studio / Gradle)** builds, across both
+> **CLI-driven** and **GUI-driven** workflows, and how that maps onto the **v1**
+> (current, CLI-only) and **v2.0** (Agent & Mount) architectures.
+>
+> **Reference project**: `superchat-platform/services/Superxpense` — React
+> Native 0.82 + Expo, native iOS (Xcode/CocoaPods) + Android (Gradle flavors),
+> Fastlane releases. Secrets in `.env.vault` (`dev`, `prod`, `ci-dev`,
+> `ci-prod`). CI orchestrated by a bespoke `scripts/ci/run-fastlane-with-vault.sh`.
+>
+> **Legend** — Platform: `[iOS]` `[Android]` `[Both]` · Context: `[CLI]` `[GUI]`
+> `[Both]` · Fits: `[v1]` doable in current architecture · `[v2]` belongs with /
+> depends on Agent & Mount · `[v2.5+]` later. Effort: `S`/`M`/`L`.
+
+---
+
+## 1. How mobile builds actually consume config
+
+Understanding the consumption side is what makes the gaps concrete. `dotenv` is **not** universally sufficient.
+
+| Consumer                              | Reads                                                                                          | Notes                                                                                                                                                                                      |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **react-native-config** (Superxpense) | `.env` (dotenv)                                                                                | Bridges dotenv → native constants (`BuildConfig` on Android, generated header/plist on iOS). Good enough for **app-level** JS/native constants.                                            |
+| **iOS build system**                  | `.xcconfig`, `Info.plist` (`$(KEY)` substitution), entitlements                                | Values the _build_ needs before app code runs — bundle-id suffix, URL schemes, SDK keys read from `Info.plist` at launch (Google Maps, some Firebase), signing. dotenv cannot reach these. |
+| **CocoaPods**                         | `ENVFILE` env var → a file path                                                                | Podfile reads a real file on disk; the file must exist.                                                                                                                                    |
+| **Android/Gradle**                    | `gradle.properties`, `local.properties`, `buildConfigField`, `resValue`, manifest placeholders | Configure-time values (signing, applicationId suffix, resource strings) the build system reads directly.                                                                                   |
+| **Firebase / Google**                 | `GoogleService-Info.plist` (iOS), `google-services.json` (Android)                             | **Real files** required even for local GUI dev builds, not just CI.                                                                                                                        |
+| **Signing (CI + local release)**      | Apple `.p8`, `.mobileprovision`, Android keystore `.jks`, Play service-account `.json`         | **Binary/file secrets.** Today stored base64 in the vault and decoded by hand in `run-fastlane-with-vault.sh`.                                                                             |
+
+Two structural truths fall out of this table:
+
+1. **dotenv-only delivery covers the RN app layer but not the native build
+   layer or file/binary secrets.** That is the single biggest source of gaps.
+2. **A single environment must fan out to several artifacts** (a `.env`, a
+   `GoogleService-Info.plist`, an `.xcconfig`, a keystore file…). Neither `run
+--export <path>` (v1) nor `mount <env> --path <file>` (v2) models "one env →
+   many typed artifacts."
+
+---
+
+## 2. Current-state matrix (what works today, v1)
+
+| Axis                         | Works today                                                                                                                                                  | Friction                                                                          |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------- |
+| `[CLI]` `[Both]`             | `vault env run <env> --export .env -- <build cmd>` wraps any spawned build (`yarn ios`, `gradlew`, `xcodebuild`, `fastlane`). File is `0600`, wiped on exit. | None for dotenv consumers. This is the sweet spot.                                |
+| `[GUI]` `[Both]`             | Pre-export `vault env export dev > .env.development`, then ⌘R / Run.                                                                                         | **Plaintext lingers indefinitely**; no auto-cleanup; password prompt every time.  |
+| `[iOS]` native settings      | —                                                                                                                                                            | No way to feed Xcode build settings or `Info.plist` (see §4.A templating).        |
+| `[Android]` native settings  | —                                                                                                                                                            | No way to feed `gradle.properties`/`buildConfigField`/`resValue` (see §4.A).      |
+| `[Both]` file/binary secrets | Manual: `echo "$VAR" \| base64 -d > file` in a script.                                                                                                       | No first-class "materialize var as decoded file." Every project re-implements it. |
+| `[Both]` orchestration       | Hand-written shell (`run-fastlane-with-vault.sh`) maps env → many files.                                                                                     | No declarative manifest; not reusable across repos.                               |
+
+---
+
+## 3. Gap catalog
+
+Each gap tagged by platform / context / version fit.
+
+| ID                                                               | Gap                                                                                                                 | Platform | Context | Fits   | Effort    |
+| ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | -------- | ------- | ------ | --------- |
+| **A. Output formats (templating — vault stays format-agnostic)** |
+| G1                                                               | No templating engine (`file.<ext>.vtpl` → `{{KEY}}` substitution → `file.<ext>`; single-pass; no format knowledge)  | Both     | Both    | v1     | M         |
+| G2                                                               | No opt-in escaping filters (`{{KEY \| json\|xml\|base64}}`) for values with format-special chars                    | Both     | Both    | v1     | S         |
+| **B. File & binary secrets**                                     |
+| G6                                                               | No "materialize var → decoded file" (`--decode base64`, mode `0600`)                                                | Both     | Both    | v1     | M         |
+| G7                                                               | No first-class handling for `GoogleService-Info.plist` / `google-services.json` as managed files                    | Both     | Both    | v1     | S         |
+| G8                                                               | No signing-asset delivery (Apple `.p8`/`.mobileprovision`, Android `.jks`, Play `.json`)                            | Both     | CLI     | v1     | M         |
+| **C. Access & session (unlock)**                                 |
+| G9                                                               | No non-interactive unlock — a GUI build / Run Script phase cannot prompt for a password                             | Both     | GUI     | **v2** | L         |
+| G10                                                              | No biometric / keychain unlock for frictionless re-unlock after auto-lock                                           | Both     | GUI     | v2.5+  | L         |
+| **D. Lifecycle & cleanup**                                       |
+| G11                                                              | Plaintext from `export >` lingers forever in the GUI flow                                                           | Both     | GUI     | **v2** | — (mount) |
+| G12                                                              | Auto-lock ↔ mounted-file contract undefined (does lock wipe live mounts?)                                          | Both     | GUI     | **v2** | S         |
+| G13                                                              | Expo `prebuild` regenerates native projects and drops injected native values                                        | Both     | Both    | v2.5+  | M         |
+| **E. IDE / build-system triggers**                               |
+| G14                                                              | No Xcode Run Script build-phase helper / documented snippet                                                         | iOS      | GUI     | v1     | S         |
+| G15                                                              | No Gradle plugin / `init.gradle` task to pull config at configure time                                              | Android  | Both    | v1     | M         |
+| G16                                                              | No VSCode / JetBrains plugin (inline resolve, run from palette)                                                     | Both     | GUI     | v3     | L         |
+| **F. Orchestration / manifest**                                  |
+| G17                                                              | No declarative delivery manifest ("env → N typed artifacts") in `.vaultrc`                                          | Both     | Both    | v1     | M         |
+| G18                                                              | `mount <env> --path` is single-file/dotenv only — cannot fan out formats                                            | Both     | GUI     | **v2** | M         |
+| **G. Scaffolding & DX**                                          |
+| G19                                                              | No `init --preset react-native` (scaffolds `.vaultrc`, `.gitignore`, xcconfig include, gradle snippet, build phase) | Both     | Both    | v1     | M         |
+| G20                                                              | No `doctor` for mobile wiring (checks envfile presence, gitignore, mount status, manifest validity)                 | Both     | Both    | v1     | S         |
+| **H. CI parity**                                                 |
+| G21                                                              | No `--ci` clean export (strip comments/metadata)                                                                    | Both     | CLI     | v2.5   | S         |
+| G22                                                              | No env-vault sync (`pull`/`push`, committed encrypted vault workflow)                                               | Both     | CLI     | v2.5   | M         |
+| **I. Agent security / threat model**                             |
+| G23                                                              | Agent must never expose a dump-all / enumeration API (a naive one lets any client drain the vault)                  | Both     | Both    | **v2** | S         |
+| G24                                                              | IPC socket reachable by any same-UID process — socket perms don't stop same-UID malware                             | Both     | Both    | **v2** | M         |
+| G25                                                              | Master key + decrypted envs resident in agent memory (ptrace / memory scrape → total loss)                          | Both     | Both    | **v2** | L         |
+| G26                                                              | Mounted plaintext readable by any same-UID process — mount is the highest-risk mode                                 | Both     | GUI     | **v2** | M         |
+| G27                                                              | No per-release approval or audit log for sensitive envs (prod/signing) — theft is silent + untraceable              | Both     | Both    | **v2** | M         |
+| G28                                                              | Auto-lock defeatable via synthetic "activity" — malware keeps the session alive indefinitely                        | Both     | Both    | **v2** | S         |
+
+---
+
+## 4. What needs to be done — by group
+
+### A. Config templating `[v1]` — **highest leverage, unblocks native iOS/Android**
+
+**Design decision: vault does _not_ own third-party formats.** An earlier draft
+proposed native emitters (`xcconfig`/`plist`/`properties`/`xml` serializers).
+That was rejected: it would force vault to understand, escape, and track the
+flavor drift of every build-config format forever — unbounded maintenance for a
+secrets tool. Instead vault does **format-agnostic templating**: the developer
+writes the format, vault only substitutes secrets into it.
+
+`dotenv` remains the **one** native serializer vault owns (it is vault's own
+format, not a third-party one — see `src/utils/dotenv.js`). Everything else is a
+template.
+
+- **G1 — templating engine.** `file.<ext>.vtpl` → substitute `{{KEY}}`
+  placeholders from the resolved `{KEY: VALUE}` map → `file.<ext>` (output path =
+  template path with `.vtpl` stripped, or an explicit `out`). Vault treats the
+  template as opaque text; it never parses the target format. Works for
+  `Secrets.xcconfig`, `Info.plist`, `gradle.properties`, `secrets.xml`, and any
+  future text format with zero new code.
+  - **Delimiter `{{KEY}}`** deliberately avoids `$( )` (xcconfig/plist) and
+    `${ }` (gradle/shell) so a template can contain the target format's own
+    interpolation tokens (`$(inherited)`, `$(SRCROOT)`, `${...}`) untouched.
+  - **Single-pass substitution** — a substituted value is never re-scanned for
+    placeholders, so one secret cannot inject a `{{OTHER_KEY}}` reference and
+    exfiltrate another. Security-relevant invariant.
+  - **Missing key** → hard error by default (no silent empty substitution).
+- **G2 — opt-in escaping filters.** Default substitution is **raw** (covers the
+  ~95% of secrets that are format-safe: API keys, URLs, DSNs). For values with
+  format-special chars, `{{KEY | json}}` / `{{KEY | xml}}` / `{{KEY | base64}}`
+  apply a small pure escaping function. These filters are the only place any
+  format knowledge lives, and they are opt-in, not mandatory. Reuse the dotenv
+  escaper's test pattern (`test(env): cover quoteDotenvValue edge cases`).
+
+> **Note for Superxpense specifically**: because it is pure RN with
+> react-native-config, dotenv already reaches the app layer. Templating matters
+> for (a) values the build system needs at configure time and (b) any future
+> non-RN native target. Add `.vtpl` files if/when build-time or SDK-at-launch
+> keys appear; otherwise B (files) is more urgent.
+
+### B. File & binary secrets `[v1]` — **most urgent for real mobile signing/Firebase**
+
+> **Boundary vs §A templating.** Use **blob delivery** (this group) when the
+> file is _entirely_ secret and vault stores it whole — Firebase plists/JSON,
+> `.jks`, `.p8`, `.mobileprovision`. Use a **`.vtpl` template** (§A/G1) when the
+> file is mostly static structure with a few secret fields, so only the secrets
+> live in the vault and the skeleton stays diffable in git. Binary/large files
+> are always blobs, never templates.
+
+- **G6** — `vault env file <KEY> --out <path> [--decode base64] [--mode 0600]`:
+  write a single var's value to a file, optionally base64-decoded, with secure
+  cleanup semantics matching `run --export`. Replaces the hand-rolled
+  `base64 -d` in `run-fastlane-with-vault.sh`.
+- **G7** — recognize known file secrets (`GoogleService-Info.plist`,
+  `google-services.json`) in the manifest (§F) so a single command drops them
+  where Xcode/Gradle expect them for **local GUI dev**, not just CI.
+- **G8** — extend G6 to the signing set (`.p8`, `.mobileprovision`, `.jks`, Play
+  `.json`); document the fastlane wiring. (Provisioning/cert _management_ à la
+  `match` stays out of scope — vault only stores & materializes.)
+
+### C. Access & session `[v2]` — **the GUI linchpin; already the v2.0 goal**
+
+- **G9** — `vault env agent start` + session-based unlock + `agent lock|unlock`
+  - launchd. Once the daemon holds the key, GUI builds never prompt. This is
+    exactly SPEC §13.5 and needs no change beyond building it.
+- **G10** — biometric/keychain unlock (SPEC §13.7) makes re-unlock after
+  auto-lock painless; pull earlier if G12 forces frequent re-unlocks.
+
+### D. Lifecycle & cleanup
+
+- **G11 `[v2]`** — `mount <env> --path` + file-watch + secure-shutdown wipe
+  replaces `export >`. Closed by v2.0 as specified.
+- **G12 `[v2]` — fix before building §13.5**: define what **auto-lock** does to
+  **live mounts**. If lock wipes them, an all-day GUI session breaks after the
+  30-min idle timeout (file vanishes → next ⌘R fails). Options: (a) keep mounts
+  live across lock, only block _new_ unlocks; (b) count build-time file reads as
+  "activity"; (c) require biometric (G10) so re-unlock is frictionless. The
+  §13.5 exit criterion ("stays live all day") does not hold until this is nailed.
+  See §5.4/§5.5 for the trade-off and §4-I/G28 for the conservative-lock rule.
+- **G13 `[v2.5+]`** — Expo config plugin / prebuild hook so injected native
+  values survive `expo prebuild`.
+
+### E. IDE / build-system triggers
+
+- **G14 `[v1]` `[iOS]`** — ship a documented Xcode **Run Script build phase**
+  that calls `vault env apply` (or `file`, against the agent session once G9
+  lands, or a pre-mounted file) to render a `.vtpl` `.xcconfig`/plist into
+  `DERIVED_FILE_DIR`. With a persistent mount (v2) this becomes optional — the
+  file is just present.
+- **G15 `[v1]` `[Android]`** — a Gradle task / `init.gradle` snippet that shells
+  to `vault env apply` at configure time to render a `gradle.properties.vtpl`.
+- **G16 `[v3]`** — VSCode / JetBrains plugin (SPEC §14.2).
+
+### F. Orchestration / manifest `[v1]` — **the piece that replaces bespoke shell**
+
+- **G17** — extend `.vaultrc` with a declarative **delivery manifest**:
+
+  ```jsonc
+  {
+    "env": "dev",
+    "deliver": [
+      // native dotenv serializer (the one format vault owns)
+      { "path": ".env.development", "format": "dotenv" },
+      // blob: whole file stored as one var, written verbatim (§B)
+      {
+        "path": "ios/GoogleService-Info.plist",
+        "from": "GOOGLE_PLIST",
+        "decode": "base64",
+      },
+      {
+        "path": "android/app/google-services.json",
+        "from": "GOOGLE_JSON",
+        "decode": "base64",
+      },
+      // template: skeleton in repo, {{KEY}} substituted (§A); out = strip .vtpl
+      { "template": "ios/Config/Secrets.xcconfig.vtpl" },
+    ],
+  }
+  ```
+
+  Three delivery kinds, distinguished by which field is present: `format`
+  (native dotenv), `from` (+ optional `decode` — blob), or `template`
+  (`.vtpl` → substitute). Vault understands the target format in **none** of
+  them except dotenv.
+
+  Add `vault env apply [env]` (v1: write all artifacts, wipe on a companion
+  `vault env clean`) — and have **v2 `agent mount` consume the same manifest**
+  so one `mount` fans out every artifact and watches them all. This unifies G6,
+  G7, G18 and retires `run-fastlane-with-vault.sh`.
+
+- **G18 `[v2]`** — `mount` reads the manifest (not a single `--path`).
+
+### G. Scaffolding & DX `[v1]`
+
+- **G19** — `vault env init --preset react-native`: scaffold `.vaultrc` (with a
+  starter manifest), `.gitignore` entries, an Xcode build-phase snippet, and a
+  Gradle snippet.
+- **G20** — `vault env doctor`: verify envfile presence, gitignore coverage,
+  manifest validity, agent/mount status; actionable fixes.
+
+### H. CI parity `[v2.5]`
+
+- **G21** — `export --format <fmt> --ci` (strip comments/metadata). SPEC §13.6.
+- **G22** — `pull`/`push` + committed-encrypted-vault workflow. SPEC §13.6.
+  (Superxpense already commits `.env.vault` and shares the password out-of-band,
+  so this is largely a formalization.)
+
+### I. Agent security / threat model `[v2]` — **design constraints, not optional features**
+
+These are not "features to add later" — they are invariants the v2.0 agent must
+satisfy from day one, or it becomes a _worse_ security posture than v1. Full
+analysis in §5.
+
+- **G23** — the agent protocol must be **request-scoped**: a client asks for one
+  environment (ideally a key subset); there is **no** `list-envs` and **no**
+  `dump-all` verb. `agent status` returns metadata only, never values.
+- **G24** — do not rely on a listening socket that any same-UID process can dial.
+  Prefer **spawn-based delivery** (agent → its own forked child over an inherited
+  fd). Where a socket is unavoidable, add `SO_PEERCRED`/`LOCAL_PEERCRED` peer
+  checks — but treat them as a speed bump, not a boundary (see §5.1).
+- **G25** — hold a **hardware-backed KEK** (Secure Enclave / Keychain / TPM),
+  **decrypt one env on demand**, never keep all environments decrypted in memory;
+  harden the process (`RLIMIT_CORE=0`, `PT_DENY_ATTACH`/`ptrace_scope`, `mlock`,
+  hardened runtime, no `get-task-allow`).
+- **G26** — treat `mount` as the **highest-risk mode**: opt-in, scoped to the
+  minimal keys, `0600` in a `0700` dir, wiped on lock. Default the GUI story to
+  run-scoped delivery; require an explicit flag + warning for a persistent mount.
+- **G27** — **per-release approval** (biometric) for sensitive envs
+  (prod/signing) + an **append-only audit log** (env, PID, binary, timestamp) so
+  theft is neither silent nor untraceable.
+- **G28** — **conservative auto-lock**: base "activity" on user-authenticated
+  actions (not raw requests), add a hard max session lifetime, and lock on
+  sleep / screen-lock. This is also the fix wired into **G12**.
+
+---
+
+## 5. Threat model — Agent & Mount
+
+The v2.0 agent keeps the vault unlocked for convenience. An unlocked, long-lived
+process holding keys is exactly what an attacker wants, so the agent's security
+must be designed, not assumed. This section defines the attacker, the surfaces,
+and the trade-offs behind the §4-I invariants.
+
+### 5.1 Attacker model & the unavoidable invariants
+
+**Attacker**: a **contaminated build process** — a malicious npm `postinstall`, a
+trojaned CocoaPod, a compromised Gradle plugin — running **as the developer's own
+UID** on the dev machine, trying to steal env vars, read sensitive files, and
+drain the vault.
+
+**The hard truth**: same-UID code is **inside your trust boundary**. It can
+`ptrace` the agent, read `/proc/<pid>/environ` of sibling processes, and read any
+`0600` file you own. **No userspace agent can fully defeat same-UID malware.**
+Any design that claims otherwise is wrong. What a good design _can_ do is contain
+the blast radius, raise the cost, and make theft noisy and auditable.
+
+Three invariants follow:
+
+- **I1 — Delivered secrets are forfeit.** Once a secret reaches a process, a
+  contaminated process has it. The goal is **not** to protect the secrets of the
+  current run (impossible) — it is to protect everything else.
+- **I2 — Containment.** A contaminated run must obtain **only** the secrets of
+  the environment it was authorized for. It must never enumerate environments,
+  reach other environments, or persist access beyond the run.
+- **I3 — No regression below v1.** v1 has _no ambient authority_ — a process only
+  gets what a `run`/`export` explicitly handed it. A naive agent (listening
+  socket + dump-all API + persistent mount) is **strictly worse** than v1 and is
+  unacceptable.
+
+### 5.2 Threat surfaces
+
+Ranked by real-world exposure to same-UID malware.
+
+| Surface               | Attack                                              | Same-UID feasibility | Mitigation                                                            | Residual risk                                      |
+| --------------------- | --------------------------------------------------- | -------------------- | --------------------------------------------------------------------- | -------------------------------------------------- |
+| **Mounted plaintext** | `cat .env`                                          | Trivial              | Opt-in only; minimal keys; `0600`/`0700`; wipe on lock (G26)          | File is readable for its whole lifetime            |
+| **Env-var injection** | read `/proc/pid/environ`; inherited by all children | Trivial              | `clean` inject; file delivery over env; inject into direct child only | Inherited by legitimate children; crash dumps      |
+| **Agent IPC socket**  | connect + request secrets                           | Trivial              | Spawn-based delivery; no dump-all; peer creds (G23, G24)              | Same-UID client can still request its own env      |
+| **Agent memory**      | `ptrace` / read process memory → KEK + all envs     | High                 | HW-backed KEK; decrypt-on-demand; anti-ptrace; `mlock` (G25)          | **Cannot be fully closed in userspace**            |
+| **Session longevity** | synthetic "activity" to defeat auto-lock            | Moderate             | User-activity-based lock; hard max lifetime; lock on sleep (G28)      | Attacker active during a legitimately-open session |
+
+### 5.3 "Can a process scan all secrets?" — answer by design
+
+| Design                                                                                             | Can an arbitrary same-UID process drain the vault?                                                                 |
+| -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| **v1 (no daemon)**                                                                                 | **No** — no ambient authority; it gets only what was handed to it.                                                 |
+| **Naive v2** (listening socket, `dump-all`, persistent mount)                                      | **Yes** — connect and ask, or read the mount, or scrape memory. Regression.                                        |
+| **Hardened v2** (spawn delivery, request-scoped, no enumeration, HW-KEK, decrypt-on-demand, audit) | **Only its own authorized env** — cannot enumerate or drain. Residual: memory scrape + its own run's secrets (I1). |
+
+### 5.4 Trade-off analysis — delivery mode
+
+How the secret reaches the build. Higher rows = safer/less convenient.
+
+| Mode                                 | Convenience | Plaintext-at-rest window | Blast radius if consumer is malware     | Best for                                  |
+| ------------------------------------ | ----------- | ------------------------ | --------------------------------------- | ----------------------------------------- |
+| **A. `run` scoped inject (`clean`)** | Medium      | None (memory only)       | This run's env only; not on disk        | CLI builds, CI (**v1 default**)           |
+| **B. `run --export` file, wiped**    | Medium      | Only during the child    | This run's env; on disk briefly         | CLI + wrapping a GUI (`open -W`) (**v1**) |
+| **C. Persistent `mount`**            | High        | Whole session            | This env, readable by any same-UID proc | All-day GUI dev — **opt-in, warned (v2)** |
+| **D. FUSE virtual FS**               | High        | None (never on disk)     | This env, via FS access controls        | v3 north star; needs kernel ext           |
+
+**Recommendation**: default GUI to **B** (wrap the IDE process; file dies when
+the IDE quits); offer **C** only behind an explicit flag with a warning; treat
+**A** as the CLI/CI default it already is. The convenience jump from B→C is real
+but it converts a child-lifetime window into a whole-session plaintext file — the
+single biggest posture downgrade in the whole feature.
+
+### 5.5 Trade-off analysis — unlock / key storage
+
+Where the unlock key lives determines resistance to memory scrape and at-rest
+theft, traded against re-unlock friction.
+
+| Storage                                 | Re-unlock friction | Resists memory scrape       | Resists at-rest theft | Notes                                               |
+| --------------------------------------- | ------------------ | --------------------------- | --------------------- | --------------------------------------------------- |
+| **1. Prompt every time (v1)**           | High (types pw)    | N/A (no daemon)             | Strong                | Safe but the exact friction v2 exists to remove     |
+| **2. Session key in agent memory**      | None               | **Weak** (ptrace)           | Weak                  | Naive agent default — avoid as the whole story      |
+| **3. OS keychain, ACL-bound to binary** | Low (per-policy)   | Medium                      | Strong                | Only the signed vault binary retrieves; good base   |
+| **4. Secure Enclave / TPM + biometric** | Low (Touch ID)     | **Strong** (non-exportable) | Strong                | KEK never leaves hardware; per-access re-auth (G10) |
+
+**Recommendation**: **3 as the floor, 4 for sensitive envs.** Combine with
+decrypt-on-demand (G25) so even a scraped agent yields at most the currently-open
+env, not the whole vault. Option 4 also makes the G12/G28 conservative auto-lock
+painless — re-unlock is a fingerprint, not a password.
+
+### 5.6 Recommended posture by context
+
+| Context                          | Default posture                                                                                   |
+| -------------------------------- | ------------------------------------------------------------------------------------------------- |
+| **CLI / CI build**               | `run` scoped `clean` inject or `--export` wiped file. No daemon needed. (v1 today.)               |
+| **Local GUI dev**                | `run --export` wrapping the IDE (mode B); HW-backed re-unlock; persistent mount opt-in + warned   |
+| **Sensitive env (prod/signing)** | Per-release biometric approval + append-only audit log (G27); decrypt-on-demand (G25)             |
+| **Untrusted / prod-grade build** | **Isolation** — run in container / VM / sandbox / ephemeral CI; agent injects across the boundary |
+
+### 5.7 The real answer to "the process is contaminated": isolation
+
+Every mitigation in §5.2–5.6 _reduces blast radius_ but cannot beat same-UID
+code (I1, memory scrape). The only design that _eliminates_ the escalation path
+is to stop running the build in the same trust domain as the agent:
+
+- Run the build in a **container / VM / sandbox** (macOS App Sandbox/seatbelt,
+  Linux namespaces + seccomp) or an **ephemeral CI runner**, and inject only the
+  scoped secrets **across the boundary**.
+- Then even total compromise of the build yields **only that build's secrets** and
+  **cannot** reach the agent, the KEK, or other environments — different
+  UID/namespace means `ptrace`, `/proc`, and the socket are all out of reach.
+
+This is the difference between _reducing_ blast radius (agent hardening, the
+pragmatic dev-laptop answer) and _eliminating_ the escalation path (isolation,
+the honest prod-grade answer). The docs must say this plainly so nobody
+over-trusts the agent.
+
+### 5.8 Explicit non-goals
+
+The agent does **not** protect against, and must not claim to:
+
+- Same-UID memory scraping of the agent (mitigated, not eliminated — §5.2).
+- Theft of the **current run's own** secrets by that run (I1).
+- A developer exfiltrating secrets they are themselves authorized to unlock.
+- Kernel-level or root compromise of the host.
+
+---
+
+## 6. Recommended sequencing
+
+The gaps split cleanly by dependency. **B + F + A are all v1 work and independent
+of the v2 agent** — they deliver value now and don't wait on the daemon.
+
+| Track                                  | Gaps                           | Version   | Rationale                                                                                                                                                                                                              |
+| -------------------------------------- | ------------------------------ | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **1. File secrets + manifest**         | G6, G7, G17, (G18-ready)       | v1.8      | Unblocks real local GUI dev (Firebase files) and retires the bespoke CI shell. Highest practical value for Superxpense today.                                                                                          |
+| **2. Config templating**               | G1, G2                         | v1.8      | Format-agnostic `.vtpl` engine; unblocks native build-time config for any text format without vault owning format flavors.                                                                                             |
+| **3. Scaffolding**                     | G19, G20                       | v1.9      | Makes tracks 1–2 adoptable across repos.                                                                                                                                                                               |
+| **4. Agent & Mount**                   | G9, G11, G12, G18, **G23–G28** | v2.0      | The GUI lifecycle win. **The §4-I / §5 security invariants (G23–G28) are non-negotiable — a naive agent regresses below v1 (I3).** Resolve G12 (lock↔mount) before implementing. Mount consumes the track-1 manifest. |
+| **5. Signing + Gradle/Xcode triggers** | G8, G14, G15                   | v2.0      | Depends on session unlock (G9) for non-interactive build phases.                                                                                                                                                       |
+| **6. Frictionless + IDE + CI**         | G10, G13, G16, G21, G22        | v2.5 / v3 | Polish and reach.                                                                                                                                                                                                      |
+
+**Bottom line:** v2.0 Agent & Mount closes the **access & lifecycle** half
+(G9, G11 — the hard part) and, for a dotenv/RN project like Superxpense, is
+_nearly_ sufficient on its own. It does **not** close the **format &
+file-secret** half (A, B) or the **orchestration** half (F) — and those are the
+gaps that make `secure-vault` first-class for _native_ iOS/Android and for the
+Firebase/signing files every mobile app needs. Those three tracks are v1 work
+and shouldn't wait on the daemon. Fix the G12 lock↔mount contract before
+building §13.5.
+
+**Security caveat:** the agent's convenience comes from keeping the vault
+unlocked, which is precisely what malware wants. Per §5, a naive agent is a
+_regression_ below v1 (I3). Build it only with the §4-I invariants in place —
+request-scoped delivery, no enumeration, HW-backed decrypt-on-demand, audited
+approval, conservative lock — and be explicit that against a same-UID
+contaminated build the agent _reduces_ blast radius but only **isolation**
+(container/VM/sandbox/CI) _eliminates_ the escalation path (§5.7).

--- a/docs/environments/MOBILE-INTEGRATION-GAPS.md
+++ b/docs/environments/MOBILE-INTEGRATION-GAPS.md
@@ -428,3 +428,243 @@ request-scoped delivery, no enumeration, HW-backed decrypt-on-demand, audited
 approval, conservative lock — and be explicit that against a same-UID
 contaminated build the agent _reduces_ blast radius but only **isolation**
 (container/VM/sandbox/CI) _eliminates_ the escalation path (§5.7).
+
+---
+
+## 7. Task breakdown
+
+Agile decomposition of the §6 tracks. Each task is a deployable unit; gap IDs in
+parentheses map back to §3/§4. Versions follow the §6 sequencing
+(v1.8/v1.9/v2.0/v2.5+).
+
+### Milestone v1.8 — Native config & file secrets (no daemon)
+
+- [ ] **Task 1: Templating engine + opt-in escaping filters** (G1, G2)
+  - **Goal**: Render `file.<ext>.vtpl` → `file.<ext>` by substituting `{{KEY}}`
+    placeholders from the resolved env map, keeping vault fully format-agnostic.
+  - **Constraints**: `{{KEY}}` delimiter only (leave target-format `$()`/`${}`
+    tokens untouched); single-pass substitution (never re-scan a substituted
+    value → no cross-secret injection); missing key = hard error; raw
+    substitution by default with opt-in `{{KEY | json|xml|base64}}` filters.
+    dotenv stays a separate native serializer (`src/utils/dotenv.js`), untouched.
+  - **Dependencies**: None.
+  - **Implementation Guidance**: The filter functions are the _only_ place any
+    format knowledge lives — keep them opt-in, never auto-detect format from
+    extension. Reuse the `quoteDotenvValue` edge-case test pattern per filter.
+    Anti-pattern to reject: per-format serializers (the discarded emitter design).
+  - **Validation**: A `.vtpl` with `$(inherited)` and `${...}` renders those
+    tokens intact; a value containing `{{X}}` is not recursively expanded;
+    `| json` on a value with `"`/newline yields valid JSON; unknown key fails
+    loudly (non-zero exit).
+
+- [ ] **Task 2: Materialize variable → decoded file (blob delivery)** (G6, G7)
+  - **Goal**: `vault env file <KEY> --out <path> [--decode base64] [--mode 0600]`
+    writes a single var's value to disk verbatim (optionally base64-decoded) with
+    `run --export` secure-cleanup semantics.
+  - **Constraints**: Default mode `0600`; reuse the existing export temp-file/wipe
+    path. Recognize known file secrets (`GoogleService-Info.plist`,
+    `google-services.json`) so they land where Xcode/Gradle expect for local GUI
+    dev, not only CI. Never write plaintext world-readable before `chmod`.
+  - **Dependencies**: None (parallel to Task 1).
+  - **Implementation Guidance**: Replaces the hand-rolled `base64 -d` in
+    `run-fastlane-with-vault.sh`. Share the `--export` lifecycle from
+    `bin/commands/envRunHelpers.js`. Blob delivery = whole file is one var; use
+    for entirely-secret/binary/large files (templates handle mostly-static files).
+  - **Validation**: A base64 var decodes to a byte-identical binary at `0600`;
+    cleanup fires on the same trigger as `run --export`; a materialized Firebase
+    plist is accepted by a sample build.
+
+- [ ] **Task 3: Delivery manifest + `apply`/`clean`** (G17, G18-ready)
+  - **Goal**: Extend `.vaultrc` with a `deliver` manifest ("one env → N
+    artifacts"); add `vault env apply [env]` (write all) and `vault env clean`
+    (wipe all).
+  - **Constraints**: Three entry kinds by field present — `format` (native
+    dotenv), `from` (+optional `decode`, blob), `template` (`.vtpl`; `out`
+    defaults to path minus `.vtpl`). Validate the manifest, fail clearly on
+    unknown format/key. `apply` idempotent; `clean` wipes exactly what `apply`
+    wrote. Manifest schema/validator is a standalone module so v2 `mount` reuses
+    it verbatim.
+  - **Dependencies**: Tasks 1, 2.
+  - **Implementation Guidance**: The piece that retires
+    `run-fastlane-with-vault.sh`. Do not couple `apply` to any daemon.
+  - **Validation**: One sample manifest produces a `.env`, a decoded Firebase
+    plist, and a rendered `xcconfig` in a single command; `clean` removes exactly
+    those; an invalid manifest is rejected with an actionable message.
+
+### Milestone v1.9 — Adoptability
+
+- [ ] **Task 4: `init --preset react-native` scaffolder** (G19)
+  - **Goal**: Scaffold a starter `.vaultrc` manifest, `.gitignore` entries,
+    `.vtpl` starter templates, and Xcode/Gradle build-phase snippets.
+  - **Constraints**: Never overwrite existing files without confirmation;
+    generated `.gitignore` covers every artifact the starter manifest emits.
+  - **Dependencies**: Task 3.
+  - **Implementation Guidance**: Reference the Superxpense layout (RN 0.82 + Expo,
+    iOS CocoaPods, Android Gradle flavors) for defaults. Snippets reference the
+    same commands `doctor` checks for.
+  - **Validation**: Running the preset in a clean RN repo yields a manifest
+    `apply` accepts and a gap-free `.gitignore`; re-running is non-destructive.
+
+- [ ] **Task 5: `doctor` for mobile wiring** (G20)
+  - **Goal**: Verify envfile presence, `.gitignore` coverage, manifest validity
+    (and later agent/mount status), emitting actionable fixes.
+  - **Constraints**: Diagnostic-only — never mutates the vault or secrets; every
+    failed check prints a concrete remediation; non-zero exit on any failure.
+  - **Dependencies**: Task 3.
+  - **Implementation Guidance**: Build a check registry so v2 agent/mount checks
+    slot in later. Reuse Task 3's manifest validator rather than re-parsing.
+  - **Validation**: Detects a manifest artifact missing from `.gitignore`; detects
+    an invalid manifest; exits non-zero on any failure, zero when clean.
+
+### Milestone v2.0 — Agent & Mount (security-gated)
+
+- [ ] **Task 6: Define the auto-lock ↔ live-mount contract (design gate)** (G12)
+  - **Goal**: Decide, in writing, what auto-lock does to live mounts — resolving
+    §5.4/§5.5 before any daemon code exists.
+  - **Constraints**: Must satisfy the §13.5 "mount stays live all day" criterion
+    without defeating auto-lock (G28). Choose among: (a) keep mounts live across
+    lock / block only new unlocks, (b) count build-time reads as activity,
+    (c) require biometric re-unlock.
+  - **Dependencies**: None — but hard-blocks Tasks 7 & 8.
+  - **Implementation Guidance**: The doc names this a mandatory pre-implementation
+    gate. Document the chosen option + residual risk in SPEC; the conservative-
+    lock rule (G28) constrains the answer.
+  - **Validation**: SPEC records a single chosen option with rationale; the choice
+    preserves both "all-day GUI session survives" and "idle/sleep locks".
+
+- [ ] **Task 7: Agent daemon + session unlock (invariants baked in)** (G9, G23–G25, G28)
+  - **Goal**: `vault env agent start` + session-based unlock + `agent lock|unlock`
+    (launchd) so GUI builds never prompt, satisfying the §4-I invariants from
+    day one.
+  - **Constraints** (non-negotiable): request-scoped protocol only — no
+    `list-envs`, no `dump-all`, `agent status` returns metadata never values
+    (G23); prefer spawn-based delivery over a listening socket,
+    `SO_PEERCRED`/`LOCAL_PEERCRED` a speed bump only (G24); HW-backed KEK,
+    decrypt one env on demand, never all resident (G25); conservative auto-lock
+    on authenticated activity + hard max lifetime + lock on sleep/screen-lock
+    (G28). Must not regress below v1's zero-ambient-authority (I3).
+  - **Dependencies**: Task 6.
+  - **Implementation Guidance**: SPEC §13.5. Harden the process: `RLIMIT_CORE=0`,
+    `PT_DENY_ATTACH`/`ptrace_scope`, `mlock`, hardened runtime, no
+    `get-task-allow`. Document non-goals (§5.8). Reject in review any verb
+    returning more than the one authorized env.
+  - **Validation**: An arbitrary same-UID process cannot enumerate or drain other
+    envs via the protocol; `agent status` exposes no values; core dumps disabled
+    and ptrace denied on-platform; idle/sleep triggers lock per Task 6.
+
+- [ ] **Task 8: `mount` consumes the delivery manifest** (G11, G18, G26)
+  - **Goal**: Replace `export >` with `mount <env>` that reads the Task-3
+    manifest, fans out every artifact, watches them, and wipes on secure
+    shutdown/lock.
+  - **Constraints**: Highest-risk mode — opt-in behind an explicit flag +
+    warning; minimal keys; `0600` in a `0700` dir; wiped on lock per Task 6
+    (G26). Default GUI story stays run-scoped delivery (mode B); persistent mount
+    (mode C) is not the default. Reuse the Task-3 manifest schema, not a separate
+    `--path` model.
+  - **Dependencies**: Tasks 3, 6, 7.
+  - **Implementation Guidance**: Unifies with `apply` so one manifest drives both
+    v1.8 file delivery and v2 mount. The warning copy must state the B→C posture
+    downgrade explicitly.
+  - **Validation**: One `mount` produces every manifest artifact with correct
+    perms; lock wipes all live mounts per Task 6; persistent mount requires the
+    explicit flag and prints the warning; without it the GUI path defaults to
+    wrapped run-scoped delivery.
+
+- [ ] **Task 9: Audit log + per-release approval for sensitive envs** (G27)
+  - **Goal**: Append-only audit log (env, PID, requesting binary, timestamp) and
+    per-release biometric approval for prod/signing envs.
+  - **Constraints**: Log append-only / tamper-evident; approval gate for
+    sensitive envs only; combine with decrypt-on-demand (G25); approval prompt
+    not spoofable by synthetic activity. Record the requesting _binary_, not just
+    PID (PIDs recycle).
+  - **Dependencies**: Task 7.
+  - **Implementation Guidance**: Ties into the biometric path (Task 12) but the
+    log itself is independent and ships with the agent.
+  - **Validation**: Every sensitive-env access appends an entry; a prod/signing
+    unlock requires explicit approval; a same-UID process cannot silently rewrite
+    the log in place (or tampering is detectable).
+
+- [ ] **Task 10: Signing-asset delivery** (G8)
+  - **Goal**: Extend blob materialization (Task 2) to the signing set — Apple
+    `.p8`/`.mobileprovision`, Android `.jks`, Play `.json` — with documented
+    Fastlane wiring.
+  - **Constraints**: Non-interactive build phases use the agent session (Task 7).
+    Provisioning/cert _management_ (à la `match`) stays out of scope — vault only
+    stores & materializes.
+  - **Dependencies**: Tasks 2, 7.
+  - **Implementation Guidance**: Removes the base64-by-hand steps from
+    `run-fastlane-with-vault.sh`; document the exact env wiring (`ENVFILE`,
+    keystore paths).
+  - **Validation**: A Fastlane release consumes vault-materialized signing assets
+    end-to-end with no manual base64; assets are `0600` and wiped after the run.
+
+- [ ] **Task 11: Xcode & Gradle build-phase triggers** (G14, G15)
+  - **Goal**: A documented Xcode Run Script phase and a Gradle task / `init.gradle`
+    snippet that call `vault env apply` to render `.vtpl` artifacts at
+    build/configure time.
+  - **Constraints**: Both run non-interactively via the agent session (Task 7);
+    with a persistent mount the file is already present, making the phase
+    optional. Xcode phase survives the sandboxed build-phase environment; Gradle
+    runs at configure time.
+  - **Dependencies**: Tasks 1, 3, 7.
+  - **Implementation Guidance**: Distribute snippets via the Task-4 preset. A full
+    Gradle plugin is out of scope — a task/snippet suffices.
+  - **Validation**: A sample Xcode build renders its `.vtpl` `xcconfig`/plist into
+    `DERIVED_FILE_DIR` with no prompt; a sample Gradle configure phase renders
+    `gradle.properties` from the vault non-interactively.
+
+### Milestone v2.5 / v3 — Frictionless, IDE, CI parity
+
+- [ ] **Task 12: Biometric / keychain unlock** (G10)
+  - **Goal**: Secure Enclave/Keychain biometric unlock so re-unlock after
+    auto-lock is a fingerprint, not a password.
+  - **Constraints**: KEK non-exportable / hardware-backed (storage option 4,
+    §5.5) with keychain-ACL-bound-to-binary as the floor (option 3); combine with
+    decrypt-on-demand so a scraped agent yields at most the currently-open env.
+  - **Dependencies**: Task 7.
+  - **Implementation Guidance**: SPEC §13.7. Pull earlier if Task 6's contract
+    forces frequent re-unlocks; makes conservative auto-lock painless.
+  - **Validation**: Re-unlock after auto-lock completes via Touch ID with no typed
+    password; the KEK is confirmed non-exportable on-platform.
+
+- [ ] **Task 13: CI parity — clean export + vault sync** (G21, G22)
+  - **Goal**: `export --ci` (strip comments/metadata) and `pull`/`push` for a
+    committed-encrypted-vault workflow.
+  - **Constraints**: `--ci` output free of comment/metadata lines that break
+    strict parsers; `pull`/`push` formalizes the existing "commit `.env.vault`,
+    share password out-of-band" pattern without weakening encryption.
+  - **Dependencies**: None (export) / Task 3 helpful.
+  - **Implementation Guidance**: SPEC §13.6. Superxpense already commits
+    `.env.vault`, so `pull`/`push` is largely formalization — match that
+    convention.
+  - **Validation**: `--ci` output has no comment/metadata lines and parses in a
+    strict CI consumer; `pull` then `push` round-trips an encrypted vault with no
+    plaintext leak.
+
+- [ ] **Task 14: Expo prebuild survival** (G13)
+  - **Goal**: Ensure injected native values survive `expo prebuild`, which
+    regenerates native projects and drops them.
+  - **Constraints**: Re-apply the manifest's native artifacts after prebuild
+    regenerates iOS/Android.
+  - **Dependencies**: Tasks 1, 3.
+  - **Implementation Guidance**: An Expo config plugin or prebuild post-hook that
+    re-runs `apply`; test against RN 0.82 + Expo.
+  - **Validation**: `expo prebuild` followed by a build retains all
+    vault-injected native values.
+
+- [ ] **Task 15: VSCode / JetBrains plugin** (G16)
+  - **Goal**: IDE plugin for inline resolve and run-from-palette.
+  - **Constraints**: Goes through the agent session (no plaintext in the plugin);
+    respects request-scoped delivery.
+  - **Dependencies**: Task 7.
+  - **Implementation Guidance**: SPEC §14.2. Lowest priority; scope tightly to
+    resolve + run.
+  - **Validation**: The plugin resolves an env and launches a run through the
+    agent without exposing values in editor state or logs.
+
+### Critical path
+
+Task 6 (lock↔mount contract) hard-gates Tasks 7–8. Tasks 1–5 (v1.8/v1.9) are
+fully daemon-independent and carry the most immediate value for Superxpense. The
+invariants in Task 7 (G23–G28) are part of its definition-of-done, not a
+follow-up — a naive agent regresses below v1.

--- a/docs/environments/SPEC.md
+++ b/docs/environments/SPEC.md
@@ -3,7 +3,7 @@
 > Feature: Securely manage, version, and inject environment variables from an encrypted
 > `.env.vault` file into development tools, build processes, and CI/CD pipelines.
 >
-> Status: **v1.5 delivered** · Revision 8
+> Status: **v1.5 delivered** · Revision 9
 
 ---
 
@@ -80,6 +80,9 @@ that require one.
 - Pre-flight validation of required variables
 - Export to `.env` format and `.env.example` (keys only)
 - CLI-only operation — no Electron UI dependency
+- _(planned, v1.8+)_ Materialize vars as decoded files (blobs) and render
+  arbitrary config files from `.vtpl` templates (§8.5); declarative delivery
+  manifest — one env → N artifacts (see `MOBILE-INTEGRATION-GAPS.md`)
 
 ### 2.2 Non-Goals (v1)
 
@@ -906,6 +909,11 @@ vault env export production > .env # SECURITY: delete after use!
 
 ```
 
+> **Output formats.** Formats beyond `dotenv`/`json` are delivered by **file
+> templating** (`.vtpl`, §8.5), not by adding new `--format` values — vault does
+> not own third-party build-config formats. See
+> `docs/environments/MOBILE-INTEGRATION-GAPS.md` §4.A.
+
 #### `vault env template`
 
 ```
@@ -1249,6 +1257,35 @@ return input
 
 ```
 
+### 8.5 File Templating (`.vtpl`) — planned (v1.8)
+
+Distinct from the value-level references above. A `.vtpl` file is a plain-text
+template **on disk**, in any format (`xcconfig`, `Info.plist`,
+`gradle.properties`, `xml`, JSON…), containing `{{KEY}}` placeholders that are
+substituted with resolved env values at render time, producing `file.<ext>`
+(output path = template path minus `.vtpl`).
+
+**Decision**: vault _renders templates_ rather than shipping native format
+emitters — it never parses or owns a third-party format. `dotenv` remains the
+one native serializer vault owns (§6.3 `export`). See
+`docs/environments/MOBILE-INTEGRATION-GAPS.md` §4.A for the full rationale.
+
+- **Delimiter `{{KEY}}`** (bare key) — deliberately distinct from `$( )`/`${ }`
+  so a template can carry the target format's own interpolation tokens
+  untouched, and distinct in intent from the namespaced value-refs
+  `{{env:…}}`/`{{vault:…}}` above: those resolve **inside stored values**;
+  `.vtpl` keys resolve against the **already-resolved env map** at file-render
+  time.
+- **Single-pass substitution** — a substituted value is never re-scanned, so one
+  secret cannot inject a `{{OTHER_KEY}}` reference to exfiltrate another. This is
+  the deliberate opposite of §8.3 rule 3, which recurses for value-refs.
+- **Missing key → hard error.** Raw substitution by default; opt-in escaping
+  filters `{{KEY | json|xml|base64}}` for values with format-special chars.
+
+Rendering is driven by the delivery manifest (`.vaultrc`) via `vault env apply`
+(v1.8) and, later, `vault env mount` (v2.0) — see MOBILE-INTEGRATION-GAPS.md
+§4.F / §7.
+
 ---
 
 ## 9. Environment Layering
@@ -1499,13 +1536,13 @@ When `--export <path>` (or the deprecated `--inject file` / `--out-file`) is use
 ### 13.1 Milestone Overview
 
 ```
-v0.5        v1.0          v1.5           v2.0            v2.5            v3.0
-│           │             │              │               │               │
-Foundation  Developer     Composition    Agent & Mount   Integration     North Star
-            CLI
-                     ▲               ▲                               ▲
-                     │               │                               │
-                     MVP            Power User                       Vision
+v0.5        v1.0        v1.5        v1.8         v1.9      v2.0          v2.5         v3.0
+│           │           │           │            │         │             │            │
+Foundation  Developer   Composition Native cfg   Scaffold  Agent &       Integration  North Star
+            CLI                     + files      & DX      Mount
+                   ▲          ▲          ▲                                        ▲
+                   │          │          │                                        │
+                   MVP       Power User  Mobile-native                           Vision
 ```
 
 > **Legend:** ✅ delivered · ◑ partial (see note) · ☐ not started. Status
@@ -1601,24 +1638,79 @@ command (recovery is currently a manual `cp <vault>.bak <vault>`).
 
 ---
 
+### 13.4.1 v1.8 — Native config & file secrets
+
+> **Goal**: Make secure-vault first-class for native iOS/Android and for the
+> Firebase/signing files every mobile app needs — **without** the v2 daemon.
+
+**Status:** ☐ Not started.
+
+| Deliverable                           | Description                                                                    |
+| ------------------------------------- | ------------------------------------------------------------------------------ |
+| `vault env file <KEY> --out`          | Materialize a var to a file, optional `--decode base64`, mode `0600` (blob)    |
+| `.vtpl` file templating               | Render any text format via `{{KEY}}` substitution + opt-in filters (§8.5)      |
+| Delivery manifest + `apply` / `clean` | `.vaultrc` "one env → N artifacts"; write all / wipe all                       |
+| Known file secrets                    | `GoogleService-Info.plist` / `google-services.json` recognized in the manifest |
+
+**Dependencies**: v1.5
+
+**Exit criteria**: one `vault env apply` drops a `.env`, a decoded
+`GoogleService-Info.plist`, and a rendered `.xcconfig` where the iOS/Android
+build expects them; `vault env clean` removes exactly those. Retires the bespoke
+`run-fastlane-with-vault.sh`. Detail: MOBILE-INTEGRATION-GAPS.md §4.A/§4.B/§4.F,
+tasks 1–3.
+
+---
+
+### 13.4.2 v1.9 — Scaffolding & DX
+
+> **Goal**: Make the v1.8 delivery adoptable across repos in one command.
+
+**Status:** ☐ Not started.
+
+| Deliverable                            | Description                                                                     |
+| -------------------------------------- | ------------------------------------------------------------------------------- |
+| `vault env init --preset react-native` | Scaffold `.vaultrc` manifest, `.gitignore`, `.vtpl` starters, build-phase snips |
+| `vault env doctor`                     | Verify envfile presence, gitignore coverage, manifest validity; actionable fix  |
+
+**Dependencies**: v1.8
+
+**Exit criteria**: a fresh RN repo is wired for vault delivery via one preset
+command, and `vault env doctor` reports green. Detail:
+MOBILE-INTEGRATION-GAPS.md §4.G, tasks 4–5.
+
+---
+
 ### 13.5 v2.0 — Agent & Mount
 
 > **Goal**: Long-running dev server support with persistent file mounts.
 
 **Status:** ☐ Not started.
 
-| Deliverable                           | Description                                               |
-| ------------------------------------- | --------------------------------------------------------- |
-| `vault env agent start\|stop\|status` | Background daemon with session-based unlock               |
-| Session auto-lock                     | Lock on inactivity timeout (configurable, default 30 min) |
-| `vault env agent lock\|unlock`        | Manual session control                                    |
-| `vault env mount <env> --path <file>` | Write + maintain a temp `.env` at the given path          |
-| File watch                            | Re-create mounted file if deleted externally              |
-| `vault env agent mounts`              | List active mounts                                        |
-| Secure shutdown                       | All mounted files wiped on agent stop                     |
-| macOS launchd integration             | Plist for auto-start on login                             |
+| Deliverable                           | Description                                                                                                                                                 |
+| ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `vault env agent start\|stop\|status` | Background daemon with session-based unlock                                                                                                                 |
+| Session auto-lock                     | Lock on inactivity timeout (configurable, default 30 min)                                                                                                   |
+| `vault env agent lock\|unlock`        | Manual session control                                                                                                                                      |
+| `vault env mount <env>`               | Consume the delivery manifest (§13.4.1); fan out + watch every artifact, wiped on lock                                                                      |
+| Persistent mount is opt-in            | Default GUI story is run-scoped delivery; persistent mount needs an explicit flag + warning (highest-risk mode)                                             |
+| Security invariants (G23–G28)         | Request-scoped protocol (no enumeration / dump-all), spawn-based delivery, HW-backed decrypt-on-demand, conservative lock, audit log + per-release approval |
+| File watch                            | Re-create mounted file if deleted externally                                                                                                                |
+| `vault env agent mounts`              | List active mounts                                                                                                                                          |
+| Secure shutdown                       | All mounted files wiped on agent stop                                                                                                                       |
+| macOS launchd integration             | Plist for auto-start on login                                                                                                                               |
 
-**Dependencies**: v1.5
+**Dependencies**: v1.9 (mount consumes the v1.8 delivery manifest; §13.4.1)
+
+> **Design gate (G12):** resolve the auto-lock ↔ live-mount contract _before_
+> implementing this milestone — does auto-lock wipe live mounts? The exit
+> criterion below does not hold until this is decided. See
+> MOBILE-INTEGRATION-GAPS.md §4.D / §5 and task 6.
+>
+> **Security invariants are preconditions, not follow-ups.** A naive agent
+> (listening socket + dump-all + persistent mount) is _strictly worse than v1_
+> (invariant I3). Build only with G23–G28 in place. Full threat model:
+> MOBILE-INTEGRATION-GAPS.md §5.
 
 **Exit criteria**: A developer starts the agent once at the start of the day, mounts their env to `.env`, and the file stays live until they lock or the agent auto-locks.
 
@@ -2083,13 +2175,14 @@ test). The write now aborts on an existing target unless `--force` is given.
 
 ## Appendix C: Changelog
 
-| Date       | Revision | Author  | Changes                                                                                                                                                                                                                                                                                                                                                                                |
-| ---------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 2026-05-30 | 1        | wbenzid | Initial draft                                                                                                                                                                                                                                                                                                                                                                          |
-| 2026-05-26 | 2        | wbenzid | Add §16 Known Issues & Pending Reconciliations (8 items from v0.1.0-rc.5 e2e validation)                                                                                                                                                                                                                                                                                               |
-| 2026-06-06 | 3        | wbenzid | Codify var-level vs env-level command split (§6.1, §6.1.1); align all §6.3 usage/examples and §7 flows to the implementation; mark §16.1–16.3 RESOLVED (option b)                                                                                                                                                                                                                      |
-| 2026-06-06 | 4        | wbenzid | Document password resolution (§6.2.1: precedence, mutual exclusion, exit codes); update §12.5; add `PASSWORD_*` codes to Appendix B; mark §16.5 RESOLVED (docs)                                                                                                                                                                                                                        |
-| 2026-06-06 | 5        | wbenzid | Document walk-up + git-root vault discovery (§5.2/§5.3); mark §16.6 RESOLVED. Fix duplicate §6.1 heading (now §6.1.1/6.1.2/6.1.3) and stale cross-refs                                                                                                                                                                                                                                 |
-| 2026-06-11 | 6        | wbenzid | Mark v1.5 Composition delivered (resolver: `extends` layering + `{{env:name/KEY}}`/`{{env:self/KEY}}` refs + full validation engine); add `.bak`/atomic-write + `.deleted.<ts>` (§5.4); reserve `self` env name (§4.5/§8); add milestone status legend + v0.5/v1.0/v2.x markers; note Q1/Q4 status in §15                                                                              |
-| 2026-06-15 | 7        | wbenzid | Mark v1.0 hardening complete in §13.3 (3-pass temp cleanup, orphan scan, distinct error codes 2–14 with symbolic emission); add `show` fields, `diff` old→new, `history` date col, spec limit enforcement, `--description`, `--quiet` to §13.4 delivered; close §16.5 (error codes); add numeric exit code column + status note to Appendix B                                          |
-| 2026-06-30 | 8        | wbenzid | Decouple `run` into two axes — population (`--inject clean\|merge`) vs file delivery (`--export <path>`); rewrite §6.3 `run` flags and §11 (now "Injection Model"); add `--set`/`--env-file`/`--force`; soft-deprecate `--inject file`/`--out-file` (removed v2.0); add §16.9 (file-mode conflation RESOLVED) and §16.10 (value escaping + overwrite guard RESOLVED); update §7.3 flow |
+| Date       | Revision | Author  | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| ---------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2026-05-30 | 1        | wbenzid | Initial draft                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| 2026-05-26 | 2        | wbenzid | Add §16 Known Issues & Pending Reconciliations (8 items from v0.1.0-rc.5 e2e validation)                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| 2026-06-06 | 3        | wbenzid | Codify var-level vs env-level command split (§6.1, §6.1.1); align all §6.3 usage/examples and §7 flows to the implementation; mark §16.1–16.3 RESOLVED (option b)                                                                                                                                                                                                                                                                                                                                                         |
+| 2026-06-06 | 4        | wbenzid | Document password resolution (§6.2.1: precedence, mutual exclusion, exit codes); update §12.5; add `PASSWORD_*` codes to Appendix B; mark §16.5 RESOLVED (docs)                                                                                                                                                                                                                                                                                                                                                           |
+| 2026-06-06 | 5        | wbenzid | Document walk-up + git-root vault discovery (§5.2/§5.3); mark §16.6 RESOLVED. Fix duplicate §6.1 heading (now §6.1.1/6.1.2/6.1.3) and stale cross-refs                                                                                                                                                                                                                                                                                                                                                                    |
+| 2026-06-11 | 6        | wbenzid | Mark v1.5 Composition delivered (resolver: `extends` layering + `{{env:name/KEY}}`/`{{env:self/KEY}}` refs + full validation engine); add `.bak`/atomic-write + `.deleted.<ts>` (§5.4); reserve `self` env name (§4.5/§8); add milestone status legend + v0.5/v1.0/v2.x markers; note Q1/Q4 status in §15                                                                                                                                                                                                                 |
+| 2026-06-15 | 7        | wbenzid | Mark v1.0 hardening complete in §13.3 (3-pass temp cleanup, orphan scan, distinct error codes 2–14 with symbolic emission); add `show` fields, `diff` old→new, `history` date col, spec limit enforcement, `--description`, `--quiet` to §13.4 delivered; close §16.5 (error codes); add numeric exit code column + status note to Appendix B                                                                                                                                                                             |
+| 2026-06-30 | 8        | wbenzid | Decouple `run` into two axes — population (`--inject clean\|merge`) vs file delivery (`--export <path>`); rewrite §6.3 `run` flags and §11 (now "Injection Model"); add `--set`/`--env-file`/`--force`; soft-deprecate `--inject file`/`--out-file` (removed v2.0); add §16.9 (file-mode conflation RESOLVED) and §16.10 (value escaping + overwrite guard RESOLVED); update §7.3 flow                                                                                                                                    |
+| 2026-07-05 | 9        | wbenzid | Record file-templating decision (§8.5): vault renders `.vtpl` templates with `{{KEY}}` substitution + opt-in escaping filters instead of native format emitters; add export output-format guardrail (§6.3) and planned goal (§2.1); add v1.8/v1.9 mobile-native milestones (§13.4.1/§13.4.2) and update the §13.1 timeline; expand §13.5 v2.0 mount to consume the delivery manifest and fold in the agent security invariants (G23–G28) + the G12 lock↔mount design gate. Detail in MOBILE-INTEGRATION-GAPS.md §4/§6/§7 |

--- a/src/__tests__/cli/envApply.integration.test.js
+++ b/src/__tests__/cli/envApply.integration.test.js
@@ -178,6 +178,15 @@ describe('vault env apply / clean (integration)', () => {
     expect(r.stderr).toMatch(/undefined variable "DOES_NOT_EXIST"/);
   });
 
+  it('fails clearly when a template file is missing', () => {
+    fs.rmSync(path.join(projectDir, 'ios/Secrets.xcconfig.vtpl'));
+    const r = cli(['apply']);
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toMatch(
+      /Cannot read template "ios\/Secrets.xcconfig.vtpl"/
+    );
+  });
+
   it('fails clearly on an invalid manifest', () => {
     fs.writeFileSync(
       path.join(projectDir, '.vaultrc'),

--- a/src/__tests__/cli/envApply.integration.test.js
+++ b/src/__tests__/cli/envApply.integration.test.js
@@ -1,0 +1,190 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CLI = path.resolve(__dirname, '../../../bin/cli.js');
+const NODE = process.execPath;
+const PASSWORD = 'TestVault123!@#';
+
+let projectDir;
+let vaultPath;
+
+// Run the CLI with cwd set to the project dir so .vaultrc discovery + relative
+// artifact paths behave like a real invocation.
+function cli(args, { cwd = projectDir } = {}) {
+  return spawnSync(NODE, [CLI, 'env', ...args], {
+    encoding: 'utf8',
+    cwd,
+    env: { ...process.env, VAULT_ENV_PASSWORD: PASSWORD },
+  });
+}
+
+const PLIST = Buffer.from('<plist>gs\x00info</plist>', 'utf-8');
+
+beforeEach(() => {
+  projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sv-apply-'));
+  // Mark the project root so .vaultrc walk-up stops here.
+  fs.mkdirSync(path.join(projectDir, '.git'));
+  vaultPath = path.join(projectDir, 'test.env.vault');
+
+  cli(['init', '-v', vaultPath]);
+  cli([
+    'set',
+    'API_URL',
+    'https://api.example.com',
+    '-e',
+    'dev',
+    '-v',
+    vaultPath,
+  ]);
+  cli([
+    'set',
+    'SENTRY_DSN',
+    'https://sentry.example',
+    '-e',
+    'dev',
+    '-v',
+    vaultPath,
+  ]);
+  cli([
+    'set',
+    'GOOGLE_PLIST',
+    PLIST.toString('base64'),
+    '-e',
+    'dev',
+    '-v',
+    vaultPath,
+  ]);
+
+  fs.mkdirSync(path.join(projectDir, 'ios'), { recursive: true });
+  fs.writeFileSync(
+    path.join(projectDir, 'ios/Secrets.xcconfig.vtpl'),
+    'API_URL = {{API_URL}}\nSENTRY_DSN = {{SENTRY_DSN}}\n'
+  );
+
+  const manifest = {
+    env: 'dev',
+    vault: vaultPath,
+    deliver: [
+      {
+        path: '.env.development',
+        format: 'dotenv',
+        keys: ['API_URL', 'SENTRY_DSN'],
+      },
+      {
+        path: 'ios/GoogleService-Info.plist',
+        from: 'GOOGLE_PLIST',
+        decode: 'base64',
+      },
+      { template: 'ios/Secrets.xcconfig.vtpl' },
+    ],
+  };
+  fs.writeFileSync(
+    path.join(projectDir, '.vaultrc'),
+    JSON.stringify(manifest, null, 2)
+  );
+});
+
+afterEach(() => {
+  try {
+    fs.rmSync(projectDir, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+describe('vault env apply / clean (integration)', () => {
+  it('fans out every artifact from the manifest with correct content and perms', () => {
+    const r = cli(['apply']);
+    expect(r.status).toBe(0);
+
+    const dotenv = fs.readFileSync(
+      path.join(projectDir, '.env.development'),
+      'utf-8'
+    );
+    expect(dotenv).toBe(
+      'API_URL=https://api.example.com\nSENTRY_DSN=https://sentry.example\n'
+    );
+
+    const plist = fs.readFileSync(
+      path.join(projectDir, 'ios/GoogleService-Info.plist')
+    );
+    expect(plist.equals(PLIST)).toBe(true);
+
+    const xcconfig = fs.readFileSync(
+      path.join(projectDir, 'ios/Secrets.xcconfig'),
+      'utf-8'
+    );
+    expect(xcconfig).toBe(
+      'API_URL = https://api.example.com\nSENTRY_DSN = https://sentry.example\n'
+    );
+
+    // eslint-disable-next-line no-bitwise
+    const mode =
+      fs.statSync(path.join(projectDir, '.env.development')).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it('resolves the same manifest from a subdirectory', () => {
+    const sub = path.join(projectDir, 'ios');
+    const r = cli(['apply'], { cwd: sub });
+    expect(r.status).toBe(0);
+    // path is relative to .vaultrc (project root), not cwd
+    expect(fs.existsSync(path.join(projectDir, '.env.development'))).toBe(true);
+  });
+
+  it('--dry-run writes nothing but still validates', () => {
+    const r = cli(['apply', '--dry-run']);
+    expect(r.status).toBe(0);
+    expect(fs.existsSync(path.join(projectDir, '.env.development'))).toBe(
+      false
+    );
+    expect(r.stdout).toMatch(/would write .env.development/);
+  });
+
+  it('clean removes exactly the manifest artifacts', () => {
+    cli(['apply']);
+    expect(fs.existsSync(path.join(projectDir, '.env.development'))).toBe(true);
+
+    const r = cli(['clean']);
+    expect(r.status).toBe(0);
+    expect(fs.existsSync(path.join(projectDir, '.env.development'))).toBe(
+      false
+    );
+    expect(
+      fs.existsSync(path.join(projectDir, 'ios/GoogleService-Info.plist'))
+    ).toBe(false);
+    expect(fs.existsSync(path.join(projectDir, 'ios/Secrets.xcconfig'))).toBe(
+      false
+    );
+    // the template source is NOT an artifact and must survive
+    expect(
+      fs.existsSync(path.join(projectDir, 'ios/Secrets.xcconfig.vtpl'))
+    ).toBe(true);
+  });
+
+  it('fails when a template references an undefined variable', () => {
+    fs.writeFileSync(
+      path.join(projectDir, 'ios/Secrets.xcconfig.vtpl'),
+      'X = {{DOES_NOT_EXIST}}\n'
+    );
+    const r = cli(['apply']);
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toMatch(/undefined variable "DOES_NOT_EXIST"/);
+  });
+
+  it('fails clearly on an invalid manifest', () => {
+    fs.writeFileSync(
+      path.join(projectDir, '.vaultrc'),
+      JSON.stringify({ env: 'dev', vault: vaultPath, deliver: [{ path: 'x' }] })
+    );
+    const r = cli(['apply']);
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toMatch(/deliver\[0\]: exactly one of/);
+  });
+});

--- a/src/__tests__/cli/envDeliverHelpers.test.js
+++ b/src/__tests__/cli/envDeliverHelpers.test.js
@@ -1,0 +1,273 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs-extra';
+import os from 'os';
+import path from 'path';
+
+import {
+  DEFAULT_FILE_MODE,
+  parseFileMode,
+  decodeValue,
+  writeArtifact,
+  normalizeDeliverEntry,
+  normalizeManifest,
+  renderDeliverEntry,
+} from '../../../bin/commands/envDeliverHelpers.js';
+
+describe('parseFileMode', () => {
+  it('defaults to 0600 for null/undefined', () => {
+    expect(parseFileMode()).toBe(0o600);
+    expect(parseFileMode(null)).toBe(DEFAULT_FILE_MODE);
+  });
+
+  it('parses 3- and 4-digit octal strings', () => {
+    expect(parseFileMode('600')).toBe(0o600);
+    expect(parseFileMode('0600')).toBe(0o600);
+    expect(parseFileMode('0644')).toBe(0o644);
+    expect(parseFileMode('0o600')).toBe(0o600);
+  });
+
+  it('passes a number through unchanged', () => {
+    expect(parseFileMode(0o640)).toBe(0o640);
+  });
+
+  it('throws on non-octal input', () => {
+    expect(() => parseFileMode('rwx')).toThrow(/Invalid file mode/);
+    expect(() => parseFileMode('0999')).toThrow(/Invalid file mode/);
+    expect(() => parseFileMode('12')).toThrow(/Invalid file mode/);
+  });
+});
+
+describe('decodeValue', () => {
+  it('returns the raw string when no decode is requested', () => {
+    expect(decodeValue('plain')).toBe('plain');
+    expect(decodeValue(null)).toBe('');
+    expect(decodeValue(undefined)).toBe('');
+  });
+
+  it('base64-decodes to a Buffer that round-trips', () => {
+    const encoded = Buffer.from('binary\x00data', 'utf-8').toString('base64');
+    const out = decodeValue(encoded, 'base64');
+    expect(Buffer.isBuffer(out)).toBe(true);
+    expect(String(out)).toBe('binary\x00data');
+  });
+
+  it('throws on an unknown decode', () => {
+    expect(() => decodeValue('x', 'rot13')).toThrow(/Unknown decode "rot13"/);
+  });
+});
+
+describe('writeArtifact', () => {
+  let dir;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'vault-deliver-test-'));
+  });
+
+  afterEach(async () => {
+    await fs.remove(dir);
+  });
+
+  it('creates missing parent directories and writes content', async () => {
+    const out = path.join(dir, 'nested/deep/secret.txt');
+    await writeArtifact(out, 'hello');
+    expect(await fs.readFile(out, 'utf-8')).toBe('hello');
+  });
+
+  it('writes at mode 0600 by default', async () => {
+    const out = path.join(dir, 'a.txt');
+    await writeArtifact(out, 'x');
+    // eslint-disable-next-line no-bitwise
+    expect((await fs.stat(out)).mode & 0o777).toBe(0o600);
+  });
+
+  it('enforces the requested mode even when overwriting a wider-permission file', async () => {
+    const out = path.join(dir, 'b.txt');
+    await fs.writeFile(out, 'old', { mode: 0o644 });
+    await writeArtifact(out, 'new', { mode: 0o600 });
+    expect(await fs.readFile(out, 'utf-8')).toBe('new');
+    // eslint-disable-next-line no-bitwise
+    expect((await fs.stat(out)).mode & 0o777).toBe(0o600);
+  });
+
+  it('writes decoded binary content byte-for-byte', async () => {
+    const out = path.join(dir, 'bin');
+    const bytes = Buffer.from([0x00, 0xff, 0x10, 0x7f]);
+    await writeArtifact(out, bytes);
+    const read = await fs.readFile(out);
+    expect(read.equals(bytes)).toBe(true);
+  });
+});
+
+describe('normalizeDeliverEntry', () => {
+  it('normalizes a format entry with an optional keys subset', () => {
+    const e = normalizeDeliverEntry({
+      path: '.env',
+      format: 'dotenv',
+      keys: ['A', 'B'],
+    });
+    expect(e).toMatchObject({
+      kind: 'format',
+      path: '.env',
+      format: 'dotenv',
+      keys: ['A', 'B'],
+      mode: 0o600,
+    });
+  });
+
+  it('normalizes a from (blob) entry with decode', () => {
+    const e = normalizeDeliverEntry({
+      path: 'ios/GoogleService-Info.plist',
+      from: 'GOOGLE_PLIST',
+      decode: 'base64',
+    });
+    expect(e).toMatchObject({
+      kind: 'from',
+      from: 'GOOGLE_PLIST',
+      decode: 'base64',
+    });
+  });
+
+  it('derives a template out path by stripping .vtpl', () => {
+    const e = normalizeDeliverEntry({ template: 'ios/Secrets.xcconfig.vtpl' });
+    expect(e).toMatchObject({
+      kind: 'template',
+      template: 'ios/Secrets.xcconfig.vtpl',
+      path: 'ios/Secrets.xcconfig',
+    });
+  });
+
+  it('honors an explicit out for a non-.vtpl template', () => {
+    const e = normalizeDeliverEntry({
+      template: 'tpl/foo',
+      out: 'build/foo.conf',
+    });
+    expect(e.path).toBe('build/foo.conf');
+  });
+
+  it('parses a per-entry mode', () => {
+    expect(
+      normalizeDeliverEntry({ path: 'x', from: 'K', mode: '0644' }).mode
+    ).toBe(0o644);
+  });
+
+  it('rejects entries without exactly one kind field', () => {
+    expect(() => normalizeDeliverEntry({ path: 'x' }, 3)).toThrow(
+      /deliver\[3\]: exactly one of/
+    );
+    expect(() =>
+      normalizeDeliverEntry({ path: 'x', format: 'dotenv', from: 'K' })
+    ).toThrow(/exactly one of/);
+  });
+
+  it('rejects an unknown format, unknown decode, and non-.vtpl template without out', () => {
+    expect(() => normalizeDeliverEntry({ path: 'x', format: 'yaml' })).toThrow(
+      /unknown format "yaml"/
+    );
+    expect(() =>
+      normalizeDeliverEntry({ path: 'x', from: 'K', decode: 'rot13' })
+    ).toThrow(/unknown decode "rot13"/);
+    expect(() => normalizeDeliverEntry({ template: 'plain.conf' })).toThrow(
+      /no .vtpl suffix/
+    );
+  });
+});
+
+describe('normalizeManifest', () => {
+  it('returns an empty list when there is no deliver key', () => {
+    expect(normalizeManifest({ env: 'dev' })).toEqual({
+      env: 'dev',
+      entries: [],
+    });
+  });
+
+  it('throws when deliver is not an array', () => {
+    expect(() => normalizeManifest({ deliver: {} })).toThrow(
+      /"deliver" must be an array/
+    );
+  });
+
+  it('normalizes every entry and surfaces the offending index', () => {
+    expect(() =>
+      normalizeManifest({
+        deliver: [{ path: '.env', format: 'dotenv' }, { path: 'x' }],
+      })
+    ).toThrow(/deliver\[1\]/);
+  });
+});
+
+describe('renderDeliverEntry', () => {
+  const vars = {
+    A: '1',
+    B: 'two',
+    GOOGLE: Buffer.from('blob').toString('base64'),
+  };
+  const noTemplates = () => {
+    throw new Error('should not read a template');
+  };
+
+  it('renders a full dotenv format entry', () => {
+    const e = normalizeDeliverEntry({ path: '.env', format: 'dotenv' });
+    expect(renderDeliverEntry(e, vars, noTemplates)).toBe(
+      `A=1\nB=two\nGOOGLE=${vars.GOOGLE}\n`
+    );
+  });
+
+  it('renders only the requested keys subset', () => {
+    const e = normalizeDeliverEntry({
+      path: '.env',
+      format: 'dotenv',
+      keys: ['A'],
+    });
+    expect(renderDeliverEntry(e, vars, noTemplates)).toBe('A=1\n');
+  });
+
+  it('renders a json format entry', () => {
+    const e = normalizeDeliverEntry({
+      path: 'c.json',
+      format: 'json',
+      keys: ['A', 'B'],
+    });
+    expect(
+      JSON.parse(String(renderDeliverEntry(e, vars, noTemplates)))
+    ).toEqual({
+      A: '1',
+      B: 'two',
+    });
+  });
+
+  it('renders a from blob, base64-decoded to a Buffer', () => {
+    const e = normalizeDeliverEntry({
+      path: 'g',
+      from: 'GOOGLE',
+      decode: 'base64',
+    });
+    const out = renderDeliverEntry(e, vars, noTemplates);
+    expect(Buffer.isBuffer(out)).toBe(true);
+    expect(String(out)).toBe('blob');
+  });
+
+  it('renders a template via the injected reader', () => {
+    const e = normalizeDeliverEntry({ template: 'x.conf.vtpl' });
+    const read = () => 'url={{A}} name={{B}}';
+    expect(renderDeliverEntry(e, vars, read)).toBe('url=1 name=two');
+  });
+
+  it('throws when a from variable is missing', () => {
+    const e = normalizeDeliverEntry({ path: 'g', from: 'NOPE' });
+    expect(() => renderDeliverEntry(e, vars, noTemplates)).toThrow(
+      /variable "NOPE" not found/
+    );
+  });
+
+  it('throws when a subset key is missing', () => {
+    const e = normalizeDeliverEntry({
+      path: '.env',
+      format: 'dotenv',
+      keys: ['ZZ'],
+    });
+    expect(() => renderDeliverEntry(e, vars, noTemplates)).toThrow(
+      /key "ZZ" not found/
+    );
+  });
+});

--- a/src/__tests__/cli/envDeliverHelpers.test.js
+++ b/src/__tests__/cli/envDeliverHelpers.test.js
@@ -8,6 +8,7 @@ import {
   DEFAULT_FILE_MODE,
   parseFileMode,
   decodeValue,
+  encodeValue,
   writeArtifact,
   normalizeDeliverEntry,
   normalizeManifest,
@@ -54,6 +55,35 @@ describe('decodeValue', () => {
 
   it('throws on an unknown decode', () => {
     expect(() => decodeValue('x', 'rot13')).toThrow(/Unknown decode "rot13"/);
+  });
+});
+
+describe('encodeValue', () => {
+  it('returns UTF-8 text when no encoding is requested', () => {
+    expect(encodeValue('plain')).toBe('plain');
+    expect(encodeValue(Buffer.from('buf'))).toBe('buf');
+    expect(encodeValue(null)).toBe('');
+  });
+
+  it('base64-encodes a Buffer of binary bytes', () => {
+    const bytes = Buffer.from([0x00, 0xff, 0x10]);
+    expect(encodeValue(bytes, 'base64')).toBe(bytes.toString('base64'));
+  });
+
+  it('base64-encodes a string via its UTF-8 bytes', () => {
+    expect(encodeValue('hello', 'base64')).toBe('aGVsbG8=');
+  });
+
+  it('round-trips with decodeValue', () => {
+    const bytes = Buffer.from('secret\x00blob');
+    const stored = encodeValue(bytes, 'base64');
+    const back = decodeValue(stored, 'base64');
+    // Buffer.isBuffer narrows the string|Buffer union for both TS and runtime.
+    expect(Buffer.isBuffer(back) && back.equals(bytes)).toBe(true);
+  });
+
+  it('throws on an unknown encoder', () => {
+    expect(() => encodeValue('x', 'rot13')).toThrow(/Unknown encode "rot13"/);
   });
 });
 

--- a/src/__tests__/cli/envFile.integration.test.js
+++ b/src/__tests__/cli/envFile.integration.test.js
@@ -140,3 +140,103 @@ describe('vault env file (integration)', () => {
     expect(fs.existsSync(out)).toBe(false);
   });
 });
+
+describe('vault env set --in / --encode (blob ingestion)', () => {
+  it('ingests a binary file as base64 and round-trips via env file --decode', () => {
+    const src = path.join(workDir, 'src-keystore.bin');
+    const original = Buffer.from([0xde, 0xad, 0xbe, 0xef, 0x00, 0x7f]);
+    fs.writeFileSync(src, original);
+
+    const setR = cli([
+      'set',
+      'KEYSTORE',
+      '--in',
+      src,
+      '--encode',
+      'base64',
+      '-e',
+      'dev',
+      '-v',
+      vaultPath,
+    ]);
+    expect(setR.status).toBe(0);
+
+    // Stored value is the base64 text.
+    const getR = cli(['get', 'KEYSTORE', '-e', 'dev', '-v', vaultPath]);
+    expect(getR.stdout.trim()).toBe(original.toString('base64'));
+
+    // Materialize it back and confirm byte-for-byte fidelity.
+    const out = path.join(workDir, 'out-keystore.bin');
+    const fileR = cli([
+      'file',
+      'KEYSTORE',
+      '--out',
+      out,
+      '--decode',
+      'base64',
+      '-e',
+      'dev',
+      '-v',
+      vaultPath,
+    ]);
+    expect(fileR.status).toBe(0);
+    expect(fs.readFileSync(out).equals(original)).toBe(true);
+  });
+
+  it('ingests a text file without encoding', () => {
+    const src = path.join(workDir, 'note.txt');
+    fs.writeFileSync(src, 'line1\nline2\n');
+    const r = cli(['set', 'NOTE', '--in', src, '-e', 'dev', '-v', vaultPath]);
+    expect(r.status).toBe(0);
+    const getR = cli(['get', 'NOTE', '-e', 'dev', '-v', vaultPath]);
+    expect(getR.stdout).toContain('line1');
+  });
+
+  it('rejects passing both a value and --in', () => {
+    const src = path.join(workDir, 'note.txt');
+    const r = cli([
+      'set',
+      'X',
+      'inline',
+      '--in',
+      src,
+      '-e',
+      'dev',
+      '-v',
+      vaultPath,
+    ]);
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toMatch(/either a value argument or --in/);
+  });
+
+  it('fails fast on an unknown --encode', () => {
+    const r = cli([
+      'set',
+      'X',
+      'v',
+      '--encode',
+      'rot13',
+      '-e',
+      'dev',
+      '-v',
+      vaultPath,
+    ]);
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toMatch(/Unknown encode "rot13"/);
+  });
+
+  it('errors clearly when --in points at a missing file', () => {
+    const r = cli([
+      'set',
+      'X',
+      '--in',
+      path.join(workDir, 'nope.bin'),
+      '-e',
+      'dev',
+      '-v',
+      vaultPath,
+    ]);
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toMatch(/Cannot read --in file/);
+  });
+});

--- a/src/__tests__/cli/envFile.integration.test.js
+++ b/src/__tests__/cli/envFile.integration.test.js
@@ -1,0 +1,142 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CLI = path.resolve(__dirname, '../../../bin/cli.js');
+const NODE = process.execPath;
+const PASSWORD = 'TestVault123!@#';
+
+let vaultPath;
+let workDir;
+
+function cli(args, extraEnv = {}) {
+  return spawnSync(NODE, [CLI, 'env', ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, VAULT_ENV_PASSWORD: PASSWORD, ...extraEnv },
+  });
+}
+
+const PLIST_BYTES = Buffer.from('<plist>binary\x00data</plist>', 'utf-8');
+
+beforeAll(() => {
+  workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sv-file-'));
+  vaultPath = path.join(workDir, 'test.env.vault');
+  cli(['init', '-v', vaultPath]);
+  cli([
+    'set',
+    'API_URL',
+    'https://api.example.com',
+    '-e',
+    'dev',
+    '-v',
+    vaultPath,
+  ]);
+  // A binary file secret stored base64-encoded, the way Firebase/keystore
+  // secrets live in the vault.
+  cli([
+    'set',
+    'GOOGLE_PLIST',
+    PLIST_BYTES.toString('base64'),
+    '-e',
+    'dev',
+    '-v',
+    vaultPath,
+  ]);
+});
+
+afterAll(() => {
+  try {
+    fs.rmSync(workDir, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+describe('vault env file (integration)', () => {
+  it('materializes a plain var at mode 0600 by default', () => {
+    const out = path.join(workDir, 'plain.txt');
+    const r = cli([
+      'file',
+      'API_URL',
+      '--out',
+      out,
+      '-e',
+      'dev',
+      '-v',
+      vaultPath,
+    ]);
+    expect(r.status).toBe(0);
+    expect(fs.readFileSync(out, 'utf-8')).toBe('https://api.example.com');
+    // eslint-disable-next-line no-bitwise
+    expect(fs.statSync(out).mode & 0o777).toBe(0o600);
+  });
+
+  it('base64-decodes a binary secret byte-for-byte', () => {
+    const out = path.join(workDir, 'ios/GoogleService-Info.plist');
+    const r = cli([
+      'file',
+      'GOOGLE_PLIST',
+      '--out',
+      out,
+      '--decode',
+      'base64',
+      '-e',
+      'dev',
+      '-v',
+      vaultPath,
+    ]);
+    expect(r.status).toBe(0);
+    // parent dir was created
+    expect(fs.readFileSync(out).equals(PLIST_BYTES)).toBe(true);
+  });
+
+  it('honors an explicit --mode', () => {
+    const out = path.join(workDir, 'moded.txt');
+    const r = cli([
+      'file',
+      'API_URL',
+      '--out',
+      out,
+      '--mode',
+      '0640',
+      '-e',
+      'dev',
+      '-v',
+      vaultPath,
+    ]);
+    expect(r.status).toBe(0);
+    // eslint-disable-next-line no-bitwise
+    expect(fs.statSync(out).mode & 0o777).toBe(0o640);
+  });
+
+  it('fails (non-zero) on an undefined key without writing a file', () => {
+    const out = path.join(workDir, 'missing.txt');
+    const r = cli(['file', 'NOPE', '--out', out, '-e', 'dev', '-v', vaultPath]);
+    expect(r.status).not.toBe(0);
+    expect(fs.existsSync(out)).toBe(false);
+  });
+
+  it('fails fast on an invalid --mode', () => {
+    const out = path.join(workDir, 'badmode.txt');
+    const r = cli([
+      'file',
+      'API_URL',
+      '--out',
+      out,
+      '--mode',
+      'rwx',
+      '-e',
+      'dev',
+      '-v',
+      vaultPath,
+    ]);
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toMatch(/Invalid file mode/);
+    expect(fs.existsSync(out)).toBe(false);
+  });
+});

--- a/src/__tests__/utils/templating.test.js
+++ b/src/__tests__/utils/templating.test.js
@@ -1,0 +1,124 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+
+import {
+  renderTemplate,
+  templateKeys,
+  FILTERS,
+} from '../../utils/templating.js';
+
+describe('renderTemplate — substitution', () => {
+  it('substitutes bare {{KEY}} placeholders', () => {
+    expect(
+      renderTemplate('API_URL = {{API_URL}}', { API_URL: 'https://x' })
+    ).toBe('API_URL = https://x');
+  });
+
+  it('tolerates whitespace inside the delimiters', () => {
+    expect(renderTemplate('{{  KEY  }}', { KEY: 'v' })).toBe('v');
+  });
+
+  it('substitutes multiple and repeated keys', () => {
+    const out = renderTemplate('{{A}}-{{B}}-{{A}}', { A: '1', B: '2' });
+    expect(out).toBe('1-2-1');
+  });
+
+  it('coerces non-string and null/undefined values', () => {
+    expect(renderTemplate('{{N}}', { N: 42 })).toBe('42');
+    expect(renderTemplate('{{Z}}', { Z: null })).toBe('');
+    expect(renderTemplate('{{U}}', { U: undefined })).toBe('');
+  });
+
+  it('renders an empty-string value (present key) without error', () => {
+    expect(renderTemplate('[{{K}}]', { K: '' })).toBe('[]');
+  });
+});
+
+describe('renderTemplate — format-agnostic safety', () => {
+  it("leaves the target format's own $() and ${} tokens untouched", () => {
+    const tpl = 'FRAMEWORK_SEARCH_PATHS = $(inherited) {{DIR}} ${OTHER}';
+    expect(renderTemplate(tpl, { DIR: '/libs' })).toBe(
+      'FRAMEWORK_SEARCH_PATHS = $(inherited) /libs ${OTHER}'
+    );
+  });
+
+  it('does not treat namespaced value-refs like {{env:self/X}} as placeholders', () => {
+    const tpl = 'raw {{env:self/API_URL}} literal';
+    expect(renderTemplate(tpl, { API_URL: 'x' })).toBe(tpl);
+  });
+
+  it('is single-pass: a substituted value containing a placeholder is not re-expanded', () => {
+    const out = renderTemplate('{{A}}', { A: '{{B}}', B: 'secret' });
+    expect(out).toBe('{{B}}');
+  });
+});
+
+describe('renderTemplate — errors', () => {
+  it('throws on an undefined variable (no silent empty substitution)', () => {
+    expect(() => renderTemplate('{{MISSING}}', {})).toThrow(
+      /undefined variable "MISSING"/
+    );
+  });
+
+  it('throws on an unknown filter', () => {
+    expect(() => renderTemplate('{{K | nope}}', { K: 'v' })).toThrow(
+      /Unknown template filter "nope"/
+    );
+  });
+
+  it('throws when template is not a string', () => {
+    expect(() => renderTemplate(null, {})).toThrow(TypeError);
+  });
+});
+
+describe('renderTemplate — filters', () => {
+  it('json escapes for embedding inside a JSON string (no wrapping quotes)', () => {
+    const out = renderTemplate('"k": "{{V | json}}"', { V: 'a"b\nc' });
+    expect(out).toBe('"k": "a\\"b\\nc"');
+    // the whole thing parses as JSON
+    expect(JSON.parse(`{${out}}`)).toEqual({ k: 'a"b\nc' });
+  });
+
+  it('xml escapes the five predefined entities, & first', () => {
+    expect(renderTemplate('{{V | xml}}', { V: `a&<>"'b` })).toBe(
+      'a&amp;&lt;&gt;&quot;&apos;b'
+    );
+  });
+
+  it('base64 encodes UTF-8 bytes', () => {
+    const out = renderTemplate('{{V | base64}}', { V: 'hello' });
+    expect(out).toBe('aGVsbG8=');
+    expect(Buffer.from(out, 'base64').toString('utf-8')).toBe('hello');
+  });
+
+  it('honors a custom filter registry', () => {
+    const out = renderTemplate(
+      '{{V | shout}}',
+      { V: 'hi' },
+      { filters: { shout: (s) => s.toUpperCase() } }
+    );
+    expect(out).toBe('HI');
+  });
+
+  it('exposes the built-in filters', () => {
+    expect(Object.keys(FILTERS).sort()).toEqual(['base64', 'json', 'xml']);
+  });
+});
+
+describe('templateKeys', () => {
+  it('returns distinct keys in first-seen order', () => {
+    expect(templateKeys('{{B}} {{A}} {{B}} {{C | json}}')).toEqual([
+      'B',
+      'A',
+      'C',
+    ]);
+  });
+
+  it('ignores non-placeholder {{...}} tokens', () => {
+    expect(templateKeys('{{env:self/X}} {{ VALID }}')).toEqual(['VALID']);
+  });
+
+  it('returns an empty array when there are no placeholders', () => {
+    expect(templateKeys('no placeholders here')).toEqual([]);
+  });
+});

--- a/src/utils/templating.js
+++ b/src/utils/templating.js
@@ -1,0 +1,115 @@
+/**
+ * File templating (`.vtpl`) — SPEC §8.5.
+ *
+ * A `.vtpl` file is a plain-text template in ANY format (xcconfig, plist,
+ * gradle.properties, xml, JSON…). Vault renders it by substituting `{{KEY}}`
+ * placeholders with resolved env values, producing the target file. Vault never
+ * parses or understands the target format — it only substitutes — so a single
+ * engine covers every current and future text format.
+ *
+ * This is deliberately distinct from the value-level references
+ * (`{{env:name/KEY}}`, resolved inside stored values by EnvironmentResolver):
+ * those recurse; `.vtpl` substitution is SINGLE-PASS so one secret can never
+ * inject a `{{OTHER_KEY}}` reference to exfiltrate another (SPEC §8.5).
+ */
+
+/**
+ * Placeholder grammar: `{{ KEY }}` or `{{ KEY | filter }}`.
+ *
+ * KEY is an env-var identifier (`[A-Za-z_][A-Za-z0-9_]*`). Tokens that do not
+ * match this exact shape — e.g. the target format's own `{{env:self/X}}`-style
+ * text or a stray `{{` — are left verbatim rather than treated as placeholders,
+ * so the engine never corrupts the surrounding format.
+ */
+const PLACEHOLDER =
+  /\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*(?:\|\s*([a-z0-9]+)\s*)?\}\}/g;
+
+/**
+ * Per-format escaping filters. Each transforms a raw value so it can be embedded
+ * safely in a target format; none add wrapping quotes — the template author
+ * supplies those (e.g. `"key": "{{SECRET | json}}"`). Filters are the ONLY place
+ * any format knowledge lives, and they are opt-in.
+ */
+export const FILTERS = {
+  // Escape for embedding inside a JSON string literal (no surrounding quotes).
+  json: (str) => {
+    const quoted = JSON.stringify(str);
+    return quoted.slice(1, -1);
+  },
+  // Escape XML/HTML metacharacters (& first, so already-escaped output is safe).
+  xml: (str) =>
+    str
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&apos;'),
+  // Base64-encode the UTF-8 bytes of the value.
+  base64: (str) => Buffer.from(str, 'utf-8').toString('base64'),
+};
+
+/**
+ * Render a `.vtpl` template string against a resolved `{KEY: VALUE}` map.
+ *
+ * @param {string} template - the raw template text.
+ * @param {Record<string, unknown>} vars - resolved environment variables.
+ * @param {object} [options]
+ * @param {Record<string, (s: string) => string>} [options.filters] - filter
+ *   registry override (defaults to FILTERS).
+ * @returns {string} the rendered output.
+ * @throws if a placeholder references a key absent from `vars`, or names a
+ *   filter that does not exist. Errors are hard by design — a missing secret
+ *   must never render as an empty string.
+ */
+export function renderTemplate(template, vars = {}, options = {}) {
+  if (typeof template !== 'string') {
+    throw new TypeError('renderTemplate: template must be a string');
+  }
+  const filters = options.filters || FILTERS;
+
+  // String.replace scans the ORIGINAL template only; substituted values are
+  // never re-scanned, which is what makes substitution single-pass.
+  return template.replace(PLACEHOLDER, (_match, key, filterName) => {
+    if (!Object.prototype.hasOwnProperty.call(vars, key)) {
+      throw new Error(`Template references undefined variable "${key}"`);
+    }
+    const raw = vars[key];
+    let value = raw == null ? '' : String(raw);
+
+    if (filterName) {
+      const filter = filters[filterName];
+      if (typeof filter !== 'function') {
+        throw new Error(
+          `Unknown template filter "${filterName}" for variable "${key}" ` +
+            `(available: ${Object.keys(filters).join(', ')})`
+        );
+      }
+      value = filter(value);
+    }
+    return value;
+  });
+}
+
+/**
+ * Report every distinct placeholder key referenced by a template (deduped, in
+ * first-seen order). Useful for `doctor`/manifest validation to check a template
+ * against an environment without rendering it.
+ *
+ * @param {string} template
+ * @returns {string[]}
+ */
+export function templateKeys(template) {
+  if (typeof template !== 'string') {
+    throw new TypeError('templateKeys: template must be a string');
+  }
+  const keys = [];
+  const seen = new Set();
+  for (const match of template.matchAll(PLACEHOLDER)) {
+    const key = match[1];
+    if (!seen.has(key)) {
+      seen.add(key);
+      keys.push(key);
+    }
+  }
+  return keys;
+}


### PR DESCRIPTION
## Summary

Deliver secrets into native mobile builds without a daemon. Vault stays
format-agnostic: it renders templates and materializes files, never
owning third-party build-config formats (SPEC §8.5).

Close the blob loop: `set --in <path>` reads a file as the value and
`--encode base64` stores binary blobs (Firebase plists, keystores) that
`env file --decode` / the delivery manifest later materialize byte-for-byte.
